### PR TITLE
feat(db): added sql and csv load script for gyeonggi card spending status

### DIFF
--- a/gyeonggi_card_spending_status.sql
+++ b/gyeonggi_card_spending_status.sql
@@ -1,0 +1,29 @@
+CREATE TABLE locallink.gyeonggi_card_spending_stats (
+    ta_ymd         CHAR(8),
+    city           VARCHAR(50),
+    cty_rgn_no     VARCHAR(20),
+    admi_cty_no    VARCHAR(20),
+    card_tpbuz_cd  VARCHAR(20),
+    card_tpbuz_nm_1 VARCHAR(100),
+    card_tpbuz_nm_2 VARCHAR(100),
+    hour           SMALLINT,
+    sex            VARCHAR(10),
+    age            SMALLINT,
+    day            SMALLINT,
+    amt            NUMERIC,
+    cnt            BIGINT
+);
+
+COMMENT ON COLUMN locallink.gyeonggi_card_spending_stats.ta_ymd IS '기준일자(YYYYMMDD)';
+COMMENT ON COLUMN locallink.gyeonggi_card_spending_stats.city IS '시명(예: 수원시)';
+COMMENT ON COLUMN locallink.gyeonggi_card_spending_stats.cty_rgn_no IS '시군지역번호';
+COMMENT ON COLUMN locallink.gyeonggi_card_spending_stats.admi_cty_no IS '행정시군번호';
+COMMENT ON COLUMN locallink.gyeonggi_card_spending_stats.card_tpbuz_cd IS '카드업종코드';
+COMMENT ON COLUMN locallink.gyeonggi_card_spending_stats.card_tpbuz_nm_1 IS '카드업종명(대분류)';
+COMMENT ON COLUMN locallink.gyeonggi_card_spending_stats.card_tpbuz_nm_2 IS '카드업종명(중분류/세분류)';
+COMMENT ON COLUMN locallink.gyeonggi_card_spending_stats.hour IS '시간(0~23)';
+COMMENT ON COLUMN locallink.gyeonggi_card_spending_stats.sex IS '성별';
+COMMENT ON COLUMN locallink.gyeonggi_card_spending_stats.age IS '연령';
+COMMENT ON COLUMN locallink.gyeonggi_card_spending_stats.day IS '요일(데이터 기준 코드)';
+COMMENT ON COLUMN locallink.gyeonggi_card_spending_stats.amt IS '이용금액';
+COMMENT ON COLUMN locallink.gyeonggi_card_spending_stats.cnt IS '이용건수';

--- a/load_gyeonggi_card_spending.sh
+++ b/load_gyeonggi_card_spending.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage:
+#   PGPASSWORD='yourpassword' \
+#   PSQL_CONN='host=localhost port=5432 dbname=yourdb user=youruser' \
+#   CSV_DIR='/Users/rudin/Documents/MicrosoftDataSchool/1st-project/data/경기도_카드소비_데이터_2025' \
+#   ./load_gyeonggi_card_spending.sh
+
+CSV_DIR="${CSV_DIR:-/Users/rudin/Documents/MicrosoftDataSchool/1st-project/data/경기도_카드소비_데이터_2025}"
+PSQL_CONN="${PSQL_CONN:-host=localhost port=5432 dbname=yourdb user=youruser}"
+CSV_ENCODING="${CSV_ENCODING:-UTF8}"
+TARGET_TABLE="${TARGET_TABLE:-locallink.gyeonggi_card_spending_stats}"
+STG_TABLE="${STG_TABLE:-locallink.gyeonggi_card_spending_stats_stg}"
+
+if [[ -z "${PGPASSWORD:-}" ]]; then
+  echo "ERROR: PGPASSWORD is not set."
+  exit 1
+fi
+
+if [[ ! -d "$CSV_DIR" ]]; then
+  echo "ERROR: CSV_DIR does not exist: $CSV_DIR"
+  exit 1
+fi
+
+shopt -s nullglob
+files=("$CSV_DIR"/*.csv)
+shopt -u nullglob
+
+if [[ ${#files[@]} -eq 0 ]]; then
+  echo "ERROR: No CSV files found in: $CSV_DIR"
+  exit 1
+fi
+
+# One-time setup
+psql "$PSQL_CONN" -v ON_ERROR_STOP=1 <<SQL
+ALTER TABLE ${TARGET_TABLE}
+ADD COLUMN IF NOT EXISTS city VARCHAR(50);
+
+CREATE TABLE IF NOT EXISTS ${STG_TABLE} (
+  ta_ymd CHAR(8),
+  cty_rgn_no VARCHAR(20),
+  admi_cty_no VARCHAR(20),
+  card_tpbuz_cd VARCHAR(20),
+  card_tpbuz_nm_1 VARCHAR(100),
+  card_tpbuz_nm_2 VARCHAR(100),
+  hour SMALLINT,
+  sex VARCHAR(10),
+  age SMALLINT,
+  day SMALLINT,
+  amt NUMERIC,
+  cnt BIGINT
+);
+SQL
+
+for f in "${files[@]}"; do
+  base="$(basename "$f" .csv)"
+  city="${base##*_}"
+  city_escaped="${city//\'/\'\'}"
+
+  echo "loading: $f (city=$city)"
+
+  psql "$PSQL_CONN" -v ON_ERROR_STOP=1 -c "TRUNCATE TABLE ${STG_TABLE};"
+
+  psql "$PSQL_CONN" -v ON_ERROR_STOP=1 -c "\copy ${STG_TABLE} (ta_ymd, cty_rgn_no, admi_cty_no, card_tpbuz_cd, card_tpbuz_nm_1, card_tpbuz_nm_2, hour, sex, age, day, amt, cnt) FROM '$f' WITH (FORMAT csv, HEADER true, ENCODING '$CSV_ENCODING')"
+
+  psql "$PSQL_CONN" -v ON_ERROR_STOP=1 <<SQL
+INSERT INTO ${TARGET_TABLE} (
+  ta_ymd, city, cty_rgn_no, admi_cty_no, card_tpbuz_cd, card_tpbuz_nm_1, card_tpbuz_nm_2,
+  hour, sex, age, day, amt, cnt
+)
+SELECT
+  ta_ymd, '${city_escaped}', cty_rgn_no, admi_cty_no, card_tpbuz_cd, card_tpbuz_nm_1, card_tpbuz_nm_2,
+  hour, sex, age, day, amt, cnt
+FROM ${STG_TABLE};
+SQL
+done
+
+echo "Done. Loaded ${#files[@]} files into $TARGET_TABLE."


### PR DESCRIPTION
<!--
PR 제목 규칙: type(scope): description
예) feat(function): add eventhub trigger
-->

## Summary
<!-- 한 줄로: 무엇을 왜 변경했는지 -->
- 경기도 카드소비 현황 2025년의 데이터의 테이블을 위한 sql문 추가 및 데이터 삽입용 sh 파일 추가

## Changes
<!-- 핵심 변경 2~5개 -->
- sql 파일 추가
- csv loader sh 파일 추가

## Test
<!-- 실행한 테스트/확인 (없으면 N/A) -->
- N/A

## Related
<!-- 이슈 자동 종료: Closes #번호 -->
- Closes #11 
