### PR TITLE
feat(db):경기도 명소 데이터 전처리 뷰 생성 및 결측치 보정

### DIFF
--- a/sql/ddl/create_view_attractions.sql
+++ b/sql/ddl/create_view_attractions.sql
@@ -1,0 +1,31 @@
+-- 기존 뷰 삭제
+DROP VIEW IF EXISTS locallink.v_filtered_attractions;
+
+-- 뷰 새로 생성
+CREATE VIEW locallink.v_filtered_attractions AS
+SELECT 
+    attraction_name,
+    phone_number,
+    
+    -- [1] 입장료 컬럼 (슬래시 앞부분 가져오기)
+    CASE 
+        WHEN additional_info LIKE '%/%' THEN TRIM(SPLIT_PART(additional_info, '/', 1))
+        WHEN additional_info IS NULL OR additional_info = '' THEN '정보 없음'
+        ELSE additional_info -- 슬래시가 없으면 통째로 보여줌
+    END AS entrance_fee,
+    
+    -- [2] 주차료 컬럼 (슬래시 뒷부분 가져오기)
+    CASE 
+        WHEN additional_info LIKE '%/%' THEN TRIM(SPLIT_PART(additional_info, '/', 2))
+        WHEN additional_info IS NULL OR additional_info = '' THEN '정보 없음'
+        ELSE '확인 필요' -- 슬래시가 없으면 주차 정보는 불확실함
+    END AS parking_fee,
+    
+    road_address,
+    lot_address,
+    latitude,
+    longitude,
+    city_county_name
+    
+FROM locallink.gyeonggi_attractions
+WHERE city_county_name IN ('수원시', '용인시', '평택시');

--- a/sql/dml/attractions-update_missing_data.sql
+++ b/sql/dml/attractions-update_missing_data.sql
@@ -1,0 +1,65 @@
+-- 트랜잭션 시작 (안전하게 처리)
+BEGIN;
+
+-- 1. 경기도박물관 (입장료 무료 / 주차 유료)
+UPDATE locallink.gyeonggi_attractions 
+SET additional_info = '무료 / 유료' 
+WHERE attraction_name = '경기도박물관';
+
+-- 2. 농촌테마파크 (입장료 무료 / 주차 유료)
+UPDATE locallink.gyeonggi_attractions 
+SET additional_info = '무료 / 유료' 
+WHERE attraction_name = '농촌테마파크';
+
+-- 3. 에버랜드 (입장료 유료 / 주차 무료,유료 혼합)
+UPDATE locallink.gyeonggi_attractions 
+SET additional_info = '유료 / 무료, 유료 혼합' 
+WHERE attraction_name = '에버랜드';
+
+-- 4. 한국민속촌 (둘 다 유료)
+UPDATE locallink.gyeonggi_attractions 
+SET additional_info = '유료 / 유료' 
+WHERE attraction_name = '한국민속촌';
+
+-- 5. 양지파인리조트 (입장료 유료 / 주차 무료)
+UPDATE locallink.gyeonggi_attractions 
+SET additional_info = '유료 / 무료' 
+WHERE attraction_name = '양지파인리조트';
+
+-- 6. 대장금파크 (입장료 유료 / 주차 무료)
+UPDATE locallink.gyeonggi_attractions 
+SET additional_info = '유료 / 무료' 
+WHERE attraction_name = '대장금파크';
+
+-- 7. 평택호관광단지 (둘 다 무료)
+UPDATE locallink.gyeonggi_attractions 
+SET additional_info = '무료 / 무료' 
+WHERE attraction_name = '평택호관광단지';
+
+-- 8. 수원화성 (둘 다 유료)
+UPDATE locallink.gyeonggi_attractions 
+SET additional_info = '유료 / 유료' 
+WHERE attraction_name = '수원화성';
+
+-- 9. 경기도어린이박물관 (둘 다 유료)
+UPDATE locallink.gyeonggi_attractions 
+SET additional_info = '유료 / 유료' 
+WHERE attraction_name = '경기도어린이박물관';
+
+-- 10. 백남준 아트센터 (입장료 무료 / 주차 유료)
+UPDATE locallink.gyeonggi_attractions 
+SET additional_info = '무료 / 유료' 
+WHERE attraction_name = '백남준 아트센터';
+
+-- 11. 와우정사 (둘 다 무료)
+UPDATE locallink.gyeonggi_attractions 
+SET additional_info = '무료 / 무료' 
+WHERE attraction_name = '와우정사';
+
+-- 12. 바람새마을 (둘 다 무료)
+UPDATE locallink.gyeonggi_attractions 
+SET additional_info = '무료 / 무료' 
+WHERE attraction_name = '바람새마을';
+
+-- 변경사항 저장
+COMMIT;


### PR DESCRIPTION
<!--
PR 제목 규칙: type(scope): description
예) feat(function): add eventhub trigger
-->

## Summary
<!-- 한 줄로: 무엇을 왜 변경했는지 -->
- 서비스 타겟 지역(수원/용인/평택) 필터링 및 입장료/주차료 파싱 로직이 적용된 전처리 뷰(v_filtered_attractions)를 생성하고, 원본 데이터의 정합성을 확보했습니다.

## Changes
<!-- 핵심 변경 2~5개 -->
- 뷰(View) 생성 및 컬럼 최적화: 불필요한 원본 컬럼을 제거하고, additional_info를 파싱하여 entrance_fee와 parking_fee로 분리하는 로직(SPLIT_PART) 적용.

- 지역 필터링 적용: WHERE 절을 통해 '수원시', '용인시', '평택시' 데이터만 추출하도록 제한.

- 데이터 보정(DML): 주요 명소 12곳의 부가정보 결측치를 입장료 / 주차료 표준 포맷으로 업데이트 .

- SQL 파일 모듈화: 데이터 보정 쿼리(dml/)와 뷰 생성 쿼리(ddl/)를 디렉터리로 분리하여 관리

## Test
<!-- 실행한 테스트/확인 (없으면 N/A) -->
- DBeaver 환경에서 뷰 생성 스크립트 실행 후, SELECT 조회 시 입장료/주차료 컬럼 분리 및 지역 필터링 정상 동작 확인.

## Related
<!-- 이슈 자동 종료: Closes #번호 -->
- Closes #25 
