### PR TITLE
Feat/move secrets to key vault

### DIFF
--- a/.github/workflows/oidc.yml
+++ b/.github/workflows/oidc.yml
@@ -1,0 +1,23 @@
+name: OIDC
+
+on:
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  oidc-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Read db-dsn metadata from Key Vault
+        run: az keyvault secret show --vault-name kv3dt1stteam2dev01 --name db-dsn --query id -o tsv

--- a/.gitignore
+++ b/.gitignore
@@ -201,6 +201,9 @@ cython_debug/
 .cursorignore
 .cursorindexingignore
 
+# Azure CLI local config/cache
+.azure/
+
 # Marimo
 marimo/_static/
 marimo/_lsp/

--- a/docs/keyvault-playbook.md
+++ b/docs/keyvault-playbook.md
@@ -1,61 +1,20 @@
-# Key Vault Playbook (Team of 5)
+# 팀원 사용 방법 (Portal only)
 
-## 목적
-- 민감정보(API 키, DB 비밀번호, 토큰)를 Git에서 분리하고 Key Vault로 일원화한다.
-- 팀원 5명이 최소한의 절차로 동일하게 운영한다.
+## 1) Key Vault 접속
+- Azure Portal -> `kv3dt1stteam2dev01` -> `비밀 (Secrets)`
 
-## 기본 원칙
-- 코드/스크립트/샘플 파일에 실제 비밀값을 넣지 않는다.
-- 운영 비밀값은 Key Vault만 사용한다.
-- 로컬 개발은 `.env`를 사용하고, `.env`는 Git에 올리지 않는다.
+## 2) 값 확인
+- 필요한 시크릿 클릭 (`db-dsn`, `naver-client-id` 등)
+- `현재 버전` 선택
+- `비밀 값 표시`로 값 확인
 
-## 역할 (최소 운영)
-- `Secret Admin` 1명:
-  - Key Vault에 시크릿 등록/수정/삭제 담당
-  - 권한: `Key Vault Secrets Officer`
-- `Developer` 4명:
-  - 코드에서 환경변수 이름만 사용
-  - Key Vault 직접 수정하지 않음
-
-## 시크릿 네이밍 규칙
-- 형식: `kebab-case`
+## 3) 로컬에 넣기
+- 각자 `.env` 또는 터미널 환경변수로 붙여넣기
 - 예시:
-  - `db-dsn`
-  - `azure-openai-key`
-  - `naver-client-secret`
-  - `weather-api-key`
+  - `DB_DSN=...`
+  - `NAVER_CLIENT_ID=...`
+  - `NAVER_CLIENT_SECRET=...`
+  - `AZURE_OPENAI_KEY=...`
 
-## 시크릿 요청 프로세스
-1. 개발자가 이슈/채널에 요청한다.
-2. 요청 양식:
-   - `환경`: dev/prod
-   - `시크릿 이름`: 예) `db-dsn`
-   - `용도`: 예) daangn crawler DB 연결
-3. Secret Admin이 Key Vault 등록 후 완료 댓글을 남긴다.
-4. 팀원은 값이 아니라 "시크릿 이름"으로 코드/설정을 연결한다.
-
-## 로컬 개발 규칙
-- `.env`에 로컬 값 저장
-- Git ignore 유지:
-  - `.env`
-  - `.azure/`
-  - `local.settings.json`
-- 샘플 파일에는 placeholder만 사용
-
-## 운영 연결 규칙 (다음 이슈 범위)
-- Function App Managed Identity 활성화
-- Managed Identity에 Key Vault 읽기 권한 부여 (`Key Vault Secrets User`)
-- App Setting에서 Key Vault reference 사용
-  - 예: `DB_DSN=@Microsoft.KeyVault(SecretUri=https://<vault>.vault.azure.net/secrets/db-dsn/)`
-
-## 보안 체크리스트
-- 신규 키 발급 시 기존 키 폐기(rotate) 여부 확인
-- PR 전 테스트 실행:
-  - `python -m unittest discover -s tests/unit -p 'test_*.py' -v`
-- 하드코딩 시크릿 검증 테스트 통과 확인:
-  - `test_no_hardcoded_secret_literals_in_repo_files`
-
-## 장애 대응
-- 키 유출 의심 시 즉시 키 재발급 + 구키 폐기
-- 영향 서비스(함수/배치) 재시작 후 정상 동작 확인
-- 이슈에 "발생 시각, 영향 범위, 조치 시간" 기록
+## 4) 실행
+- 같은 터미널 세션에서 스크립트 실행

--- a/docs/keyvault-playbook.md
+++ b/docs/keyvault-playbook.md
@@ -1,0 +1,61 @@
+# Key Vault Playbook (Team of 5)
+
+## 목적
+- 민감정보(API 키, DB 비밀번호, 토큰)를 Git에서 분리하고 Key Vault로 일원화한다.
+- 팀원 5명이 최소한의 절차로 동일하게 운영한다.
+
+## 기본 원칙
+- 코드/스크립트/샘플 파일에 실제 비밀값을 넣지 않는다.
+- 운영 비밀값은 Key Vault만 사용한다.
+- 로컬 개발은 `.env`를 사용하고, `.env`는 Git에 올리지 않는다.
+
+## 역할 (최소 운영)
+- `Secret Admin` 1명:
+  - Key Vault에 시크릿 등록/수정/삭제 담당
+  - 권한: `Key Vault Secrets Officer`
+- `Developer` 4명:
+  - 코드에서 환경변수 이름만 사용
+  - Key Vault 직접 수정하지 않음
+
+## 시크릿 네이밍 규칙
+- 형식: `kebab-case`
+- 예시:
+  - `db-dsn`
+  - `azure-openai-key`
+  - `naver-client-secret`
+  - `weather-api-key`
+
+## 시크릿 요청 프로세스
+1. 개발자가 이슈/채널에 요청한다.
+2. 요청 양식:
+   - `환경`: dev/prod
+   - `시크릿 이름`: 예) `db-dsn`
+   - `용도`: 예) daangn crawler DB 연결
+3. Secret Admin이 Key Vault 등록 후 완료 댓글을 남긴다.
+4. 팀원은 값이 아니라 "시크릿 이름"으로 코드/설정을 연결한다.
+
+## 로컬 개발 규칙
+- `.env`에 로컬 값 저장
+- Git ignore 유지:
+  - `.env`
+  - `.azure/`
+  - `local.settings.json`
+- 샘플 파일에는 placeholder만 사용
+
+## 운영 연결 규칙 (다음 이슈 범위)
+- Function App Managed Identity 활성화
+- Managed Identity에 Key Vault 읽기 권한 부여 (`Key Vault Secrets User`)
+- App Setting에서 Key Vault reference 사용
+  - 예: `DB_DSN=@Microsoft.KeyVault(SecretUri=https://<vault>.vault.azure.net/secrets/db-dsn/)`
+
+## 보안 체크리스트
+- 신규 키 발급 시 기존 키 폐기(rotate) 여부 확인
+- PR 전 테스트 실행:
+  - `python -m unittest discover -s tests/unit -p 'test_*.py' -v`
+- 하드코딩 시크릿 검증 테스트 통과 확인:
+  - `test_no_hardcoded_secret_literals_in_repo_files`
+
+## 장애 대응
+- 키 유출 의심 시 즉시 키 재발급 + 구키 폐기
+- 영향 서비스(함수/배치) 재시작 후 정상 동작 확인
+- 이슈에 "발생 시각, 영향 범위, 조치 시간" 기록

--- a/infra/docker/docker-compose.yml
+++ b/infra/docker/docker-compose.yml
@@ -5,9 +5,9 @@ services:
     build: .   # <-- 핵심: 현재 폴더(.)에 있는 Dockerfile을 사용해 빌드하라는 뜻
     container_name: geo-ai-db
     environment:
-      POSTGRES_USER: admin_user
-      POSTGRES_PASSWORD: 1111
-      POSTGRES_DB: postgres
+      POSTGRES_USER: ${POSTGRES_USER:-admin_user}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}
+      POSTGRES_DB: ${POSTGRES_DB:-postgres}
     ports:
       - "5433:5432"
     volumes:

--- a/scripts/ingest/bootstrap_and_run_daangn_once.ps1
+++ b/scripts/ingest/bootstrap_and_run_daangn_once.ps1
@@ -2,7 +2,16 @@ $ErrorActionPreference = 'Stop'
 
 $RootDir = (Resolve-Path (Join-Path $PSScriptRoot "..\..")).Path
 $DbContainer = if ($env:DB_CONTAINER) { $env:DB_CONTAINER } else { "geo-ai-db" }
-$DbDsn = if ($env:DB_DSN) { $env:DB_DSN } else { "postgresql://admin_user:1111@localhost:5433/postgres" }
+$DbDsn = if ($env:DB_DSN) { $env:DB_DSN } else { "" }
+$PostgresUser = if ($env:POSTGRES_USER) { $env:POSTGRES_USER } else { "admin_user" }
+$PostgresDb = if ($env:POSTGRES_DB) { $env:POSTGRES_DB } else { "postgres" }
+
+if (-not $DbDsn) {
+    throw "DB_DSN is not set."
+}
+if (-not $env:POSTGRES_PASSWORD) {
+    throw "POSTGRES_PASSWORD is not set."
+}
 
 Set-Location $RootDir
 
@@ -10,10 +19,10 @@ Write-Host "[1/5] Start local DB container"
 docker compose -f infra/docker/docker-compose.yml up -d db | Out-Null
 
 Write-Host "[2/5] Apply schema SQL"
-Get-Content sql/ddl/daangn_community_tables.sql -Raw | docker exec -i $DbContainer psql -U admin_user -d postgres | Out-Null
+Get-Content sql/ddl/daangn_community_tables.sql -Raw | docker exec -i $DbContainer psql -U $PostgresUser -d $PostgresDb | Out-Null
 
 Write-Host "[3/5] Apply target dongs seed SQL"
-Get-Content sql/dml/daangn_target_dongs_seed.sql -Raw | docker exec -i $DbContainer psql -U admin_user -d postgres | Out-Null
+Get-Content sql/dml/daangn_target_dongs_seed.sql -Raw | docker exec -i $DbContainer psql -U $PostgresUser -d $PostgresDb | Out-Null
 
 Write-Host "[4/5] Run one-time crawler"
 $env:DB_DSN = $DbDsn
@@ -23,7 +32,7 @@ if ($LASTEXITCODE -ne 0) {
 }
 
 Write-Host "[5/5] Verify inserted rows"
-docker exec -i $DbContainer psql -U admin_user -d postgres `
+docker exec -i $DbContainer psql -U $PostgresUser -d $PostgresDb `
   -c "SELECT COUNT(*) AS post_cnt FROM daangn.community_posts WHERE source_url LIKE 'https://www.daangn.com/kr/community/%' AND source_url <> 'https://www.daangn.com/kr/community';" `
   -c "SELECT COUNT(*) AS comment_cnt FROM daangn.community_comments WHERE comment_key NOT LIKE 'comment_key_smoke_%';" `
   -c "SELECT p.city_name, p.dong_name, p.title, left(c.comment_body,80) AS comment_sample FROM daangn.community_comments c JOIN daangn.community_posts p ON p.post_key = c.post_key ORDER BY c.id DESC LIMIT 5;"

--- a/scripts/ingest/bootstrap_and_run_daangn_once.sh
+++ b/scripts/ingest/bootstrap_and_run_daangn_once.sh
@@ -3,7 +3,19 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
 DB_CONTAINER="${DB_CONTAINER:-geo-ai-db}"
-DB_DSN="${DB_DSN:-postgresql://admin_user:1111@localhost:5433/postgres}"
+DB_DSN="${DB_DSN:-}"
+POSTGRES_USER="${POSTGRES_USER:-admin_user}"
+POSTGRES_DB="${POSTGRES_DB:-postgres}"
+
+if [[ -z "$DB_DSN" ]]; then
+  echo "ERROR: DB_DSN is not set."
+  exit 1
+fi
+
+if [[ -z "${POSTGRES_PASSWORD:-}" ]]; then
+  echo "ERROR: POSTGRES_PASSWORD is not set."
+  exit 1
+fi
 
 cd "$ROOT_DIR"
 
@@ -11,16 +23,16 @@ echo "[1/5] Start local DB container"
 docker compose -f infra/docker/docker-compose.yml up -d db
 
 echo "[2/5] Apply schema SQL"
-cat sql/ddl/daangn_community_tables.sql | docker exec -i "$DB_CONTAINER" psql -U admin_user -d postgres >/dev/null
+cat sql/ddl/daangn_community_tables.sql | docker exec -i "$DB_CONTAINER" psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" >/dev/null
 
 echo "[3/5] Apply target dongs seed SQL"
-cat sql/dml/daangn_target_dongs_seed.sql | docker exec -i "$DB_CONTAINER" psql -U admin_user -d postgres >/dev/null
+cat sql/dml/daangn_target_dongs_seed.sql | docker exec -i "$DB_CONTAINER" psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" >/dev/null
 
 echo "[4/5] Run one-time crawler"
 DB_DSN="$DB_DSN" ./.venv/bin/python scripts/ingest/run_daangn_crawl_once.py
 
 echo "[5/5] Verify inserted rows"
-docker exec -i "$DB_CONTAINER" psql -U admin_user -d postgres \
+docker exec -i "$DB_CONTAINER" psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" \
   -c "SELECT COUNT(*) AS post_cnt FROM daangn.community_posts WHERE source_url LIKE 'https://www.daangn.com/kr/community/%' AND source_url <> 'https://www.daangn.com/kr/community';" \
   -c "SELECT COUNT(*) AS comment_cnt FROM daangn.community_comments WHERE comment_key NOT LIKE 'comment_key_smoke_%';" \
   -c "SELECT p.city_name, p.dong_name, p.title, left(c.comment_body,80) AS comment_sample FROM daangn.community_comments c JOIN daangn.community_posts p ON p.post_key = c.post_key ORDER BY c.id DESC LIMIT 5;"

--- a/src/collectors/load_review_pipeline.py
+++ b/src/collectors/load_review_pipeline.py
@@ -29,11 +29,11 @@ EMBEDDING_API_VERSION = os.getenv("AZURE_OPENAI_EMBEDDING_API_VERSION", "2023-05
 
 # PostgreSQL DB 접속 정보 (Docker-compose 설정과 동일)
 DB_CONFIG = {
-    "host": "localhost",
-    "port": 5433,
-    "database": "postgres",
-    "user": "admin_user",
-    "password": "1111"
+    "host": os.getenv("DB_HOST", "localhost"),
+    "port": int(os.getenv("DB_PORT", "5433")),
+    "database": os.getenv("DB_NAME", "postgres"),
+    "user": os.getenv("DB_USER", "admin_user"),
+    "password": os.getenv("DB_PASSWORD", "")
 }
 
 # ==============================================================================

--- a/src/functions/daangn_weekly_crawler/README.md
+++ b/src/functions/daangn_weekly_crawler/README.md
@@ -33,6 +33,16 @@ func start
 - `WEBSITE_TIME_ZONE`: `Korea Standard Time`
 - `DB_DSN`: PostgreSQL 접속 문자열
 
+## Key Vault 권장 설정
+- 운영 환경에서는 `DB_DSN`을 코드/파일에 하드코딩하지 않고 Azure Key Vault에서 주입합니다.
+- Function App의 Managed Identity를 활성화하고 Key Vault `Secrets User` 권한을 부여합니다.
+- App Setting 예시:
+  - `DB_DSN = @Microsoft.KeyVault(SecretUri=https://<keyvault-name>.vault.azure.net/secrets/db-dsn/)`
+
+## 로컬 실행 시 필수 환경변수
+- `DB_DSN`
+- `POSTGRES_PASSWORD` (docker compose postgres 컨테이너 기동 시 필요)
+
 ## 주의
 - `daangn.target_dongs.dong_slug`가 비어 있으면 해당 동은 스킵됩니다.
 - 페이지 셀렉터는 서비스 구조 변경 시 수정이 필요합니다.

--- a/src/functions/daangn_weekly_crawler/local.settings.sample.json
+++ b/src/functions/daangn_weekly_crawler/local.settings.sample.json
@@ -3,7 +3,7 @@
   "Values": {
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME": "python",
-    "DB_DSN": "postgresql://admin_user:1111@localhost:5433/postgres",
+    "DB_DSN": "SET_IN_LOCAL_ENV_OR_KEY_VAULT",
     "TIMER_CRON": "0 0 3 * * 1",
     "WEBSITE_TIME_ZONE": "Korea Standard Time",
     "DAANGN_KEYWORDS": "맛집,명소,행사",

--- a/tests/unit/test_secret_config_contract.py
+++ b/tests/unit/test_secret_config_contract.py
@@ -1,0 +1,63 @@
+import importlib.util
+import os
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT_DIR = Path(__file__).resolve().parents[2]
+
+
+def _load_run_once_module():
+    module_path = ROOT_DIR / "scripts" / "ingest" / "run_daangn_crawl_once.py"
+    spec = importlib.util.spec_from_file_location("run_daangn_crawl_once", module_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("Cannot load run_daangn_crawl_once module")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class TestSecretConfigContract(unittest.TestCase):
+    def test_run_once_requires_db_dsn(self):
+        module = _load_run_once_module()
+        previous = os.environ.pop("DB_DSN", None)
+        try:
+            with self.assertRaises(RuntimeError):
+                module.main()
+        finally:
+            if previous is not None:
+                os.environ["DB_DSN"] = previous
+
+    def test_no_hardcoded_secret_literals_in_repo_files(self):
+        # These files are part of runtime and local execution paths.
+        target_files = [
+            ROOT_DIR / "infra" / "docker" / "docker-compose.yml",
+            ROOT_DIR / "scripts" / "ingest" / "bootstrap_and_run_daangn_once.sh",
+            ROOT_DIR / "scripts" / "ingest" / "bootstrap_and_run_daangn_once.ps1",
+            ROOT_DIR / "src" / "collectors" / "load_review_pipeline.py",
+            ROOT_DIR / "src" / "functions" / "daangn_weekly_crawler" / "local.settings.sample.json",
+        ]
+        forbidden_patterns = [
+            re.compile(r"postgresql://[^:\s]+:[^@\s]+@"),
+            re.compile(r"POSTGRES_PASSWORD:\s+[\"']?[A-Za-z0-9._-]+"),
+            re.compile(r"[\"']password[\"']\s*:\s*[\"'][^\"']+[\"']"),
+            re.compile(r"1111"),
+        ]
+
+        findings = []
+        for file_path in target_files:
+            text = file_path.read_text(encoding="utf-8")
+            for pattern in forbidden_patterns:
+                if pattern.search(text):
+                    findings.append(f"{file_path}: {pattern.pattern}")
+
+        self.assertEqual(
+            findings,
+            [],
+            "Hardcoded secret-like literals found:\n" + "\n".join(findings),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Key Vault 기반 시크릿 관리로 전환하기 위한 코드/설정 정리와 팀 사용 가이드를 반영했습니다.

## Changes
- 하드코딩된 DB/시크릿 값을 제거하고 환경변수 기반으로 전환했습니다 (`load_review_pipeline.py`, function sample settings, ingest scripts, docker-compose).
- Key Vault 사용을 전제로 실행 스크립트의 필수 환경변수 검증 로직을 추가했습니다.
- 하드코딩 시크릿 검출 및 필수 설정 계약을 확인하는 유닛 테스트를 추가했습니다 (`tests/unit/test_secret_config_contract.py`).
- 로컬 Azure CLI 캐시가 추적되지 않도록 `.gitignore`를 업데이트했습니다 (`.azure/`).
- 팀원이 Azure Portal만으로 사용할 수 있도록 Key Vault 가이드를 단순화했습니다 (`docs/keyvault-playbook.md`).

## Test
- `./.venv/bin/python -m unittest discover -s tests/unit -p 'test_*.py' -v` (11 passed)
- Key Vault 시크릿 주입 후 대표 실행 검증
- 일부 스크립트는 외부 조건(데이터 파일/DB 스키마/크롤링 데이터 품질)으로 완전 성공하지 못함을 확인

## Related
- Closes #36 
