### PR TITLE
feat(db): 위키백과 API 및 Selenium 크롤링을 통한 명소 상세 데이터 보강

### DIFF
--- a/scripts/ingest/fetch_tour_descriptions.py
+++ b/scripts/ingest/fetch_tour_descriptions.py
@@ -1,0 +1,240 @@
+import os
+import time
+import urllib.parse
+import psycopg2
+import wikipediaapi
+from dotenv import load_dotenv
+from azure.identity import DefaultAzureCredential
+from azure.keyvault.secrets import SecretClient
+
+# Selenium 관련 라이브러리
+from selenium import webdriver
+from selenium.webdriver.chrome.service import Service
+from selenium.webdriver.chrome.options import Options
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+from webdriver_manager.chrome import ChromeDriverManager
+
+# 1. 초기 설정 및 환경 변수 로드
+load_dotenv()
+urllib3_warnings = False # 경고 무시 설정
+
+_vault_url = os.getenv("KEY_VAULT_URL")
+_credential = DefaultAzureCredential()
+_kv_client = SecretClient(vault_url=_vault_url, credential=_credential)
+
+def _get_secret(name: str) -> str:
+    return _kv_client.get_secret(name).value
+
+DB_CONFIG = {
+    "host": os.getenv("DB_HOST", "localhost"),
+    "port": int(os.getenv("DB_PORT", "5433")),
+    "database": os.getenv("DB_NAME", "postgres"),
+    "user": os.getenv("DB_USER", "admin_user"),
+    "password": _get_secret("db-password"),
+}
+
+# 2. 위키백과 API 설정
+wiki = wikipediaapi.Wikipedia(
+    user_agent='LocalLinkProject/1.0 (contact@example.com)',
+    language='ko'
+)
+
+def extract_history_section(page):
+    """위키백과 특정 섹션(역사 등) 추출"""
+    target_keywords = ['역사', '유래', '연혁', '건립', '배경', '변천', '축성', '기원', '발자취']
+    def find_recursive(sections):
+        for section in sections:
+            if any(kw in section.title for kw in target_keywords):
+                return section.text.strip()
+            found = find_recursive(section.sections)
+            if found: return found
+        return None
+    return find_recursive(page.sections)
+
+def init_driver():
+    """Selenium 드라이버 초기화 (Headless 모드)"""
+    chrome_options = Options()
+    chrome_options.add_argument("--headless") # 창 숨김
+    chrome_options.add_argument("--disable-gpu")
+    chrome_options.add_argument("--no-sandbox")
+    chrome_options.add_argument("window-size=1920x1080")
+    chrome_options.add_argument("user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36")
+    
+    driver = webdriver.Chrome(service=Service(ChromeDriverManager().install()), options=chrome_options)
+    return driver
+
+def crawl_ggtour_selenium(driver, original_nm):
+    """경기관광포털 크롤링 및 데이터 반환"""
+    # 괄호 및 특수 표현 제거한 키워드로 검색 (매칭률 향상)
+    clean_keyword = original_nm.split('(')[0].split('[')[0].split(' 중 ')[0].strip()
+    
+    # 중복명 처리 (예: 수원광주이씨고택수원광주이씨고택 -> 수원광주이씨고택)
+    if "고택수원광주" in clean_keyword:
+        clean_keyword = "수원광주이씨고택"
+    
+    encoded_nm = urllib.parse.quote(clean_keyword)
+    search_url = f"https://ggtour.or.kr/travel-info/tourism-info?area-select=0&keyword-input={encoded_nm}&sort-select=0&sort=RECENTLY"
+    
+    try:
+        driver.get(search_url)
+        wait = WebDriverWait(driver, 8) 
+        wait.until(EC.presence_of_element_located((By.CLASS_NAME, "txt-wrap")))
+
+        items = driver.find_elements(By.CLASS_NAME, "txt-wrap")
+        detail_path = None
+
+        # 부분 매칭: 검색 결과 중 일치도가 높은 항목 찾기
+        for item in items:
+            try:
+                web_title = item.find_element(By.TAG_NAME, "strong").text.replace(" ", "")
+                clean_kw_normalized = clean_keyword.replace(" ", "")
+                
+                # 정확히 일치하거나 검색어가 포함되면 선택
+                if web_title == clean_kw_normalized or clean_kw_normalized in web_title:
+                    detail_path = item.get_attribute("onclick").split("'")[1]
+                    break
+            except:
+                continue
+        
+        # 부분 매칭 실패 시 첫 번째 결과 사용
+        if not detail_path and items:
+            try:
+                detail_path = items[0].get_attribute("onclick").split("'")[1]
+            except:
+                return None
+        
+        if not detail_path:
+            return None
+
+        # 상세 페이지 이동
+        driver.get(f"https://ggtour.or.kr{detail_path}")
+        wait.until(EC.presence_of_element_located((By.CLASS_NAME, "overview")))
+
+        # 기본 정보 파싱
+        overview = driver.find_element(By.CLASS_NAME, "overview").text.strip()
+        
+        # 홈페이지 URL 추출
+        source_url = f"https://ggtour.or.kr{detail_path}" 
+        try:
+            hp_li = driver.find_element(By.CSS_SELECTOR, "li.website.homePageLi")
+            href = hp_li.find_element(By.TAG_NAME, "a").get_attribute("href")
+            if href and not href.endswith('-'): 
+                source_url = href
+        except: pass
+
+        # 추가정보 4종 파싱
+        info = {}
+        info_lis = driver.find_elements(By.CSS_SELECTOR, ".moreinfo-wrap ul li")
+        for li in info_lis:
+            try:
+                k = li.find_element(By.TAG_NAME, "strong").text.strip()
+                v = li.find_element(By.TAG_NAME, "span").text.strip()
+                info[k] = v
+            except: continue
+
+        return {
+            "overview": overview,
+            "source_url": source_url,
+            "use_time": info.get("이용시간"),
+            "closed_days": info.get("휴무일"),
+            "parking": info.get("주차시설"),
+            "pet_allowed": info.get("반려동물동반가능")
+        }
+    except:
+        return None
+
+def main():
+    conn = psycopg2.connect(**DB_CONFIG)
+    cur = conn.cursor()
+    driver = init_driver()
+
+    try:
+        print("--- [최종 통합] 데이터 보강 프로세스 시작 ---")
+        cur.execute("SELECT tourist_nm FROM locallink.tourist_spot_info")
+        targets = cur.fetchall()
+
+        for i, (name,) in enumerate(targets, 1):
+            if not name: continue
+            print(f"[{i}/{len(targets)}] {name} 처리 중...", end=' ', flush=True)
+
+            # 변수 초기화
+            history, wiki_url = None, None
+            overview, source_url = None, None
+            use_time, closed_days, parking, pet_allowed = None, None, None, None
+
+            # 0. DB에서 해당 명소의 overview 확인 - 있으면 SKIP
+            cur.execute("SELECT overview FROM locallink.attraction_descriptions WHERE attraction_name = %s;", (name,))
+            existing = cur.fetchone()
+            
+            if existing and existing[0]:  # overview가 이미 존재하면
+                print("[이미 적재됨]")
+                continue
+
+            # 1. 위키백과 조회
+            search_kw = name.split('(')[0].split('[')[0].strip()
+            # 중복명 처리
+            if "고택수원광주" in search_kw:
+                search_kw = "수원광주이씨고택"
+            
+            try:
+                page = wiki.page(search_kw)
+                if page.exists():
+                    history = extract_history_section(page)
+                    wiki_url = page.fullurl
+                    print("(Wiki OK)", end=' ')
+            except: pass
+
+            # 2. 경기관광포털 크롤링 (무조건 할당 로직)
+            gg_data = crawl_ggtour_selenium(driver, name)
+            
+            if gg_data:
+                print("(GGtour OK)", end=' ')
+                # [수정 포인트] 역사 정보 유무와 상관없이 overview와 추가정보를 채움
+                overview = gg_data['overview']
+                source_url = gg_data['source_url'] # 크롤링한 URL을 우선 순위로 설정
+                use_time = gg_data['use_time']
+                closed_days = gg_data['closed_days']
+                parking = gg_data['parking']
+                pet_allowed = gg_data['pet_allowed']
+            else:
+                # 크롤링 실패 시에만 위키 URL을 출처로 사용
+                source_url = wiki_url
+                print("(GGtour Skip)", end=' ')
+
+            # 3. DB UPSERT (데이터가 하나라도 있으면 실행)
+            if history or overview:
+                upsert_query = """
+                    INSERT INTO locallink.attraction_descriptions 
+                    (attraction_name, overview, history, source_url, use_time, closed_days, parking, pet_allowed)
+                    VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+                    ON CONFLICT (attraction_name) DO UPDATE SET 
+                        overview = COALESCE(EXCLUDED.overview, attraction_descriptions.overview),
+                        history = COALESCE(EXCLUDED.history, attraction_descriptions.history),
+                        source_url = COALESCE(EXCLUDED.source_url, attraction_descriptions.source_url),
+                        use_time = EXCLUDED.use_time,
+                        closed_days = EXCLUDED.closed_days,
+                        parking = EXCLUDED.parking,
+                        pet_allowed = EXCLUDED.pet_allowed,
+                        crawled_at = NOW()
+                """
+                cur.execute(upsert_query, (
+                    name, overview, history, source_url,
+                    use_time, closed_days, parking, pet_allowed
+                ))
+                conn.commit()
+                print("[완료]")
+            else:
+                print("[데이터 없음]")
+
+            time.sleep(0.3)
+
+    finally:
+        driver.quit()
+        cur.close()
+        conn.close()
+        print("\n--- 전체 공정 완료 ---")
+
+if __name__ == "__main__":
+    main()

--- a/sql/ddl/create_attraction_descriptions.sql
+++ b/sql/ddl/create_attraction_descriptions.sql
@@ -1,0 +1,26 @@
+-- 테이블 생성
+CREATE TABLE locallink.attraction_descriptions (
+    attraction_name  VARCHAR(255) NOT NULL,
+    overview         TEXT,
+    history          TEXT,
+    source_url       TEXT,
+    crawled_at       TIMESTAMPTZ,
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    use_time         TEXT,
+    closed_days      TEXT,
+    parking          TEXT,
+    pet_allowed      TEXT
+);
+
+-- 컬럼 코멘트
+COMMENT ON TABLE  locallink.attraction_descriptions              IS '관광 명소 위키백과 수집 데이터';
+COMMENT ON COLUMN locallink.attraction_descriptions.attraction_name IS '명소 이름 (gyeonggi_attractions.attraction_name 참조)';
+COMMENT ON COLUMN locallink.attraction_descriptions.overview     IS '명소 개요 (위키백과 요약, 최대 1000자)';
+COMMENT ON COLUMN locallink.attraction_descriptions.history      IS '명소 역사/유래 (위키백과 역사 섹션 또는 본문 발췌)';
+COMMENT ON COLUMN locallink.attraction_descriptions.source_url   IS '데이터 출처 URL (위키백과 전체 URL)';
+COMMENT ON COLUMN locallink.attraction_descriptions.crawled_at   IS '마지막 크롤링 일시 (NULL이면 위키 데이터 없음)';
+COMMENT ON COLUMN locallink.attraction_descriptions.created_at   IS '레코드 최초 생성 일시';
+COMMENT ON COLUMN locallink.attraction_descriptions.use_time     IS '이용 시간 정보';
+COMMENT ON COLUMN locallink.attraction_descriptions.closed_days  IS '휴무일 정보';
+COMMENT ON COLUMN locallink.attraction_descriptions.parking      IS '주차 가능 여부 및 주차 정보';
+COMMENT ON COLUMN locallink.attraction_descriptions.pet_allowed  IS '반려동물 동반 가능 여부';

--- a/sql/ddl/create_tourist_spot_info.sql
+++ b/sql/ddl/create_tourist_spot_info.sql
@@ -1,0 +1,48 @@
+-- 1. 기존 테이블 삭제 (깔끔한 재시작을 위해)
+DROP TABLE IF EXISTS tourist_spot_info;
+
+-- 2. 테이블 생성
+CREATE TABLE locallink.tourist_spot_info (
+    tourist_nm        VARCHAR(255) NOT NULL, -- 관광정보명
+    tel_no            VARCHAR(50),           -- 전화번호
+    base_date         DATE,                  -- 데이터기준일자
+    road_addr         TEXT,                  -- 정제도로명주소
+    lot_addr          TEXT,                  -- 정제지번주소
+    zip_code          VARCHAR(20),           -- 정제우편번호
+    lat               NUMERIC(20, 10),       -- 정제WGS84위도
+    lng               NUMERIC(20, 10),       -- 정제WGS84경도
+    sigun_nm          VARCHAR(50)            -- 시군명
+);
+
+-- 3. 한글 코멘트 등록
+COMMENT ON TABLE tourist_spot_info IS '관광지 정보 마스터 테이블';
+
+COMMENT ON COLUMN tourist_spot_info.tourist_nm IS '관광정보명';
+COMMENT ON COLUMN tourist_spot_info.tel_no     IS '전화번호';
+COMMENT ON COLUMN tourist_spot_info.base_date  IS '데이터기준일자';
+COMMENT ON COLUMN tourist_spot_info.road_addr  IS '정제도로명주소';
+COMMENT ON COLUMN tourist_spot_info.lot_addr   IS '정제지번주소';
+COMMENT ON COLUMN tourist_spot_info.zip_code   IS '정제우편번호';
+COMMENT ON COLUMN tourist_spot_info.lat        IS '정제WGS84위도';
+COMMENT ON COLUMN tourist_spot_info.lng        IS '정제WGS84경도';
+COMMENT ON COLUMN tourist_spot_info.sigun_nm   IS '시군명';
+
+
+-- 데이터 정제
+DELETE FROM locallink.tourist_spot_info
+WHERE sigun_nm NOT IN ('수원시', '평택시', '용인시');
+
+DELETE FROM locallink.tourist_spot_info
+WHERE tourist_nm='용인농촌테마파크와 연꽃단지  (용인8경 중 제4경)';
+
+-- 중복행 확인
+SELECT tourist_nm, COUNT(*)
+FROM locallink.tourist_spot_info
+GROUP BY tourist_nm
+HAVING COUNT(*) > 1;
+---- 총 14개 행이 2번씩 중복됨
+
+-- 중복행 삭제 
+DELETE FROM locallink.tourist_spot_info a
+USING locallink.tourist_spot_info b
+WHERE a.tourist_nm = b.tourist_nm;


### PR DESCRIPTION
<!--
PR 제목 규칙: type(scope): description
예) feat(function): add eventhub trigger
-->

## Summary
<!-- 한 줄로: 무엇을 왜 변경했는지 -->
- 위키백과 API와 경기관광포털 Selenium 크롤링을 결합하여 경기도 내 명소의 역사(History), 개요(Overview) 및 실용 정보(이용시간, 주차 등)를 통합 적재합니다.

## Changes
<!-- 핵심 변경 2~5개 -->
- 데이터 수집 로직 구현: wikipedia-api를 통한 역사 정보 추출 및 경기관광포털의 실용 정보를 조합하여 데이터 수집
- Selenium Headless 크롤링 도입: 자바스크립트 기반 동적 페이지인 경기관광포털을 우회하기 위해 driver.get() 및 onclick 경로 직접 추출 방식 적용
- 데이터 상호 보완 구조 설계: 위키백과 정보 부재 시 관광포털의 overview를 대체재로 사용하고, 출처(source_url)를 유연하게 선택하도록 구현
- 안정적인 DB Upsert: ON CONFLICT 및 COALESCE 구문을 사용하여 기존 데이터를 보존하면서 새로운 정보만 선별적으로 업데이트

## Test
<!-- 실행한 테스트/확인 (없으면 N/A) -->
- 명소에 대해 SUCCESS 응답 및 DB 정상 적재 확인 완료 (LALA DB에 올려둠)

## Related
<!-- 이슈 자동 종료: Closes #번호 -->
- Closes #62 
