### PR TITLE
feat(frontend(ios)): lala feature enhancement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -222,3 +222,4 @@ artifacts/**
 **/*.xcuserstate
 **/*.xccheckout
 **/*.xcscmblueprint
+**/.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -223,3 +223,4 @@ artifacts/**
 **/*.xccheckout
 **/*.xcscmblueprint
 **/.DS_Store
+src/frontend/ios/LALA/LALA/Config/AppConfig.local.plist

--- a/docs/ios-flask-api-connection.md
+++ b/docs/ios-flask-api-connection.md
@@ -1,0 +1,52 @@
+# iOS Flask API Connection Guide
+
+This project uses the Flask web app as the API backend for iOS.
+iOS calls the same endpoints used by web:
+
+- `/api/places`
+- `/api/weather`
+
+## 1) When Flask is deployed, set iOS API URL immediately
+
+Use one of these commands from repository root:
+
+```bash
+.venv/bin/python scripts/sync_ios_api_base_url_from_keyvault.py --url https://<deployed-flask-domain> --check
+```
+
+or (if Key Vault secret is already prepared):
+
+```bash
+.venv/bin/python scripts/sync_ios_api_base_url_from_keyvault.py --secret <secret-name> --check
+```
+
+`--check` validates both endpoints before writing config.
+
+## 2) Where the URL is stored
+
+The script writes:
+
+- `src/frontend/ios/LALA/LALA/Config/AppConfig.local.plist`
+
+This file is ignored by git and should remain local per environment.
+
+## 3) iOS runtime loading order
+
+iOS resolves API base URL in this order:
+
+1. `Config/AppConfig.local.plist` (`API_BASE_URL`)
+2. `Config/AppConfig.plist` (`API_BASE_URL`)
+3. `Info.plist` key `LALA_API_BASE_URL`
+
+## 4) Expected URL format
+
+- Must start with `https://` or `http://`
+- Do not use `localhost` or `127.0.0.1`
+
+## 5) Quick verification
+
+After syncing config:
+
+1. Build and run the iOS app.
+2. Open main map screen.
+3. Confirm places and weather are loaded (no network/config banner).

--- a/scripts/sync_ios_api_base_url_from_keyvault.py
+++ b/scripts/sync_ios_api_base_url_from_keyvault.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Sync iOS API base URL from Azure Key Vault into AppConfig.local.plist.
+
+Usage:
+  .venv/bin/python scripts/sync_ios_api_base_url_from_keyvault.py
+  .venv/bin/python scripts/sync_ios_api_base_url_from_keyvault.py --secret lala-api-base-url
+  .venv/bin/python scripts/sync_ios_api_base_url_from_keyvault.py --url https://my-flask-app.example.com --check
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import plistlib
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+DEFAULT_SECRET_CANDIDATES = [
+    "lala-ios-api-base-url",
+    "lala-api-base-url",
+    "lala-web-base-url",
+    "frontend-api-base-url",
+    "web-base-url",
+    "api-base-url",
+]
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+OUTPUT_PATH = PROJECT_ROOT / "src/frontend/ios/LALA/LALA/Config/AppConfig.local.plist"
+
+# Allow importing project-level modules when this script is run directly.
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+def _normalize_url(value: str) -> str:
+    trimmed = value.strip()
+    if not trimmed:
+        raise ValueError("API base URL is empty.")
+    if not (trimmed.startswith("https://") or trimmed.startswith("http://")):
+        raise ValueError(f"API base URL must start with http:// or https://: {trimmed}")
+    return trimmed.rstrip("/")
+
+
+def _get_vault():
+    from config.vault_manager import vault
+    return vault
+
+
+def _read_secret_value(secret_name: str) -> str | None:
+    value = _get_vault().get_secret(secret_name)
+    if value is None:
+        return None
+
+    return _normalize_url(value)
+
+
+def _resolve_api_base_url(secret_name: str | None) -> tuple[str, str]:
+    candidates = [secret_name] if secret_name else DEFAULT_SECRET_CANDIDATES
+
+    for candidate in candidates:
+        if candidate is None:
+            continue
+        value = _read_secret_value(candidate)
+        if value:
+            return candidate, value
+
+    tried = ", ".join(c for c in candidates if c)
+    raise RuntimeError(f"No usable API base URL secret found. Tried: {tried}")
+
+
+def _suggest_secret_names() -> list[str]:
+    names = _get_vault().list_secret_names()
+    if not names:
+        return []
+
+    keywords = ("url", "base", "api", "web")
+    ranked = [name for name in names if any(keyword in name.lower() for keyword in keywords)]
+    return ranked[:10]
+
+
+def _write_plist(api_base_url: str) -> None:
+    OUTPUT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    payload = {"API_BASE_URL": api_base_url}
+
+    with OUTPUT_PATH.open("wb") as fp:
+        plistlib.dump(payload, fp, sort_keys=True)
+
+
+def _check_api_health(api_base_url: str) -> None:
+    encoded = urllib.parse.urlencode(
+        {
+            "lat": "37.2636",
+            "lng": "127.0286",
+            "radius": "3000",
+            "category": "all",
+        }
+    )
+    urls = [
+        f"{api_base_url}/api/places?{encoded}",
+        f"{api_base_url}/api/weather?lat=37.2636&lng=127.0286",
+    ]
+
+    for url in urls:
+        try:
+            with urllib.request.urlopen(url, timeout=8) as response:
+                status_code = response.getcode()
+                if status_code != 200:
+                    raise RuntimeError(f"Health check failed: {url} returned {status_code}")
+                body = response.read().decode("utf-8", errors="replace").strip()
+                if body:
+                    json.loads(body)
+        except urllib.error.HTTPError as error:
+            raise RuntimeError(f"Health check failed: {url} returned HTTP {error.code}") from error
+        except urllib.error.URLError as error:
+            raise RuntimeError(f"Health check failed: {url} is unreachable ({error.reason})") from error
+        except json.JSONDecodeError as error:
+            raise RuntimeError(f"Health check failed: {url} did not return JSON") from error
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Sync iOS API base URL into AppConfig.local.plist from Key Vault or explicit URL."
+    )
+    parser.add_argument(
+        "--url",
+        help="Explicit deployed Flask base URL (for example: https://your-app.example.com).",
+    )
+    parser.add_argument(
+        "--secret",
+        help="Key Vault secret name for API base URL. If omitted, known candidates are tried.",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Call /api/places and /api/weather before writing plist.",
+    )
+    args = parser.parse_args()
+
+    if args.url and args.secret:
+        raise SystemExit("Use either --url or --secret, not both.")
+
+    try:
+        if args.url:
+            source_name = "manual-url"
+            api_base_url = _normalize_url(args.url)
+        else:
+            source_name, api_base_url = _resolve_api_base_url(args.secret)
+
+        if args.check:
+            _check_api_health(api_base_url)
+
+        _write_plist(api_base_url)
+    except Exception as error:
+        hint = ""
+        if not args.url:
+            suggestions = _suggest_secret_names()
+            if suggestions:
+                hint = f" Candidate secrets: {', '.join(suggestions)}"
+        raise SystemExit(f"Failed to sync iOS API base URL: {error}.{hint}") from error
+
+    print(f"Synced iOS API base URL from '{source_name}' -> {OUTPUT_PATH}")
+    print(f"API_BASE_URL={api_base_url}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/frontend/ios/LALA/LALA.xcodeproj/project.pbxproj
+++ b/src/frontend/ios/LALA/LALA.xcodeproj/project.pbxproj
@@ -257,10 +257,8 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = "LALA - Local Area, Local Answer";
-				INFOPLIST_KEY_LALA_API_BASE_URL = "http://localhost:5000";
+				INFOPLIST_KEY_LALA_API_BASE_URL = "";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.travel";
-				INFOPLIST_KEY_NSAppTransportSecurity_NSAllowsLocalNetworking = YES;
-				INFOPLIST_KEY_NSAppTransportSecurity_NSExceptionDomains_localhost_NSExceptionAllowsInsecureHTTPLoads = YES;
 				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "LALA는 현재 위치 기반으로 경기도 로컬 명소와 맛집을 추천하기 위해 위치 정보가 필요합니다.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -295,10 +293,8 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = "LALA - Local Area, Local Answer";
-				INFOPLIST_KEY_LALA_API_BASE_URL = "http://localhost:5000";
+				INFOPLIST_KEY_LALA_API_BASE_URL = "";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.travel";
-				INFOPLIST_KEY_NSAppTransportSecurity_NSAllowsLocalNetworking = YES;
-				INFOPLIST_KEY_NSAppTransportSecurity_NSExceptionDomains_localhost_NSExceptionAllowsInsecureHTTPLoads = YES;
 				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "LALA는 현재 위치 기반으로 경기도 로컬 명소와 맛집을 추천하기 위해 위치 정보가 필요합니다.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;

--- a/src/frontend/ios/LALA/LALA.xcodeproj/project.pbxproj
+++ b/src/frontend/ios/LALA/LALA.xcodeproj/project.pbxproj
@@ -257,7 +257,10 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = "LALA - Local Area, Local Answer";
+				INFOPLIST_KEY_LALA_API_BASE_URL = "http://localhost:5000";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.travel";
+				INFOPLIST_KEY_NSAppTransportSecurity_NSAllowsLocalNetworking = YES;
+				INFOPLIST_KEY_NSAppTransportSecurity_NSExceptionDomains_localhost_NSExceptionAllowsInsecureHTTPLoads = YES;
 				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "LALA는 현재 위치 기반으로 경기도 로컬 명소와 맛집을 추천하기 위해 위치 정보가 필요합니다.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -292,7 +295,10 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = "LALA - Local Area, Local Answer";
+				INFOPLIST_KEY_LALA_API_BASE_URL = "http://localhost:5000";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.travel";
+				INFOPLIST_KEY_NSAppTransportSecurity_NSAllowsLocalNetworking = YES;
+				INFOPLIST_KEY_NSAppTransportSecurity_NSExceptionDomains_localhost_NSExceptionAllowsInsecureHTTPLoads = YES;
 				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "LALA는 현재 위치 기반으로 경기도 로컬 명소와 맛집을 추천하기 위해 위치 정보가 필요합니다.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;

--- a/src/frontend/ios/LALA/LALA/Config/AppConfig.plist
+++ b/src/frontend/ios/LALA/LALA/Config/AppConfig.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>API_BASE_URL</key>
+    <string></string>
+</dict>
+</plist>

--- a/src/frontend/ios/LALA/LALA/ContentView.swift
+++ b/src/frontend/ios/LALA/LALA/ContentView.swift
@@ -182,8 +182,6 @@ private struct PrivacyNoticeSheet: View {
             return PrivacyNoticeContent.titleKo
         case .english:
             return PrivacyNoticeContent.titleEn
-        case .japanese:
-            return PrivacyNoticeContent.titleJa
         }
     }
 
@@ -193,8 +191,6 @@ private struct PrivacyNoticeSheet: View {
             return PrivacyNoticeContent.summaryKo
         case .english:
             return PrivacyNoticeContent.summaryEn
-        case .japanese:
-            return PrivacyNoticeContent.summaryJa
         }
     }
 
@@ -204,8 +200,6 @@ private struct PrivacyNoticeSheet: View {
             return PrivacyNoticeContent.detailKo
         case .english:
             return PrivacyNoticeContent.detailEn
-        case .japanese:
-            return PrivacyNoticeContent.detailJa
         }
     }
 
@@ -215,8 +209,6 @@ private struct PrivacyNoticeSheet: View {
             return "동의 안내"
         case .english:
             return "Terms of Agree"
-        case .japanese:
-            return "同意案内"
         }
     }
 
@@ -226,8 +218,6 @@ private struct PrivacyNoticeSheet: View {
             return "동의하고 계속하기"
         case .english:
             return "Agree and Continue"
-        case .japanese:
-            return "同意して続行"
         }
     }
 }
@@ -269,8 +259,6 @@ private struct LocationConsentSheet: View {
             return "위치기반 정보 제공 동의"
         case .english:
             return "Location Consent"
-        case .japanese:
-            return "位置情報提供への同意"
         }
     }
 
@@ -280,8 +268,6 @@ private struct LocationConsentSheet: View {
             return "LALA는 현재 위치를 기반으로 주변 로컬 명소와 맛집을 추천합니다. 동의 후 iOS 위치 권한 허용이 필요합니다."
         case .english:
             return "LALA uses your current location to recommend nearby local places. iOS location permission is required."
-        case .japanese:
-            return "LALAは現在地を基準に周辺のローカル名所とグルメをおすすめします。同意後にiOS位置権限が必要です。"
         }
     }
 
@@ -291,8 +277,6 @@ private struct LocationConsentSheet: View {
             return "동의하고 위치 권한 요청"
         case .english:
             return "Agree and Request Location"
-        case .japanese:
-            return "同意して位置権限を要求"
         }
     }
 }
@@ -350,8 +334,6 @@ private struct LocationRequiredOverlay: View {
             return "위치 권한이 필요합니다"
         case .english:
             return "Location Permission Required"
-        case .japanese:
-            return "位置情報の権限が必要です"
         }
     }
 
@@ -361,8 +343,6 @@ private struct LocationRequiredOverlay: View {
             return "iOS 위치 사용이 꺼져 있어 LALA를 실행할 수 없습니다.\n앱 설정에서 위치 권한을 '사용하는 동안'으로 켜주세요."
         case .english:
             return "LALA cannot run while iOS location access is off.\nPlease enable location permission for this app in Settings."
-        case .japanese:
-            return "iOSの位置情報がオフのためLALAを利用できません。\n設定でこのアプリの位置情報権限を有効にしてください。"
         }
     }
 
@@ -372,8 +352,6 @@ private struct LocationRequiredOverlay: View {
             return "앱 위치 설정 열기"
         case .english:
             return "Open App Location Settings"
-        case .japanese:
-            return "アプリの位置設定を開く"
         }
     }
 
@@ -383,8 +361,6 @@ private struct LocationRequiredOverlay: View {
             return "다시 확인"
         case .english:
             return "Check Again"
-        case .japanese:
-            return "再確認"
         }
     }
 }

--- a/src/frontend/ios/LALA/LALA/ContentView.swift
+++ b/src/frontend/ios/LALA/LALA/ContentView.swift
@@ -145,22 +145,22 @@ private struct PrivacyNoticeSheet: View {
         NavigationStack {
             ScrollView {
                 VStack(alignment: .leading, spacing: 14) {
-                    Text(language == .korean ? PrivacyNoticeContent.titleKo : PrivacyNoticeContent.titleEn)
+                    Text(privacyTitle)
                         .font(.system(size: 20 * fontScale, weight: .bold))
-                    Text(language == .korean ? PrivacyNoticeContent.summaryKo : PrivacyNoticeContent.summaryEn)
+                    Text(privacySummary)
                         .font(.system(size: 15 * fontScale, weight: .medium))
                         .foregroundStyle(.secondary)
-                    Text(language == .korean ? PrivacyNoticeContent.detailKo : PrivacyNoticeContent.detailEn)
+                    Text(privacyDetail)
                         .font(.system(size: 14 * fontScale))
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(16)
             }
-            .navigationTitle(language == .korean ? "동의 안내" : "Terms of Agree")
+            .navigationTitle(sheetTitle)
             .navigationBarTitleDisplayMode(.inline)
             .safeAreaInset(edge: .bottom) {
                 Button(action: onAgree) {
-                    Text(language == .korean ? "동의하고 계속하기" : "Agree and Continue")
+                    Text(agreeButtonTitle)
                         .font(.system(size: 17 * fontScale, weight: .bold))
                         .foregroundStyle(.white)
                         .frame(maxWidth: .infinity)
@@ -175,6 +175,61 @@ private struct PrivacyNoticeSheet: View {
             }
         }
     }
+
+    private var privacyTitle: String {
+        switch language {
+        case .korean:
+            return PrivacyNoticeContent.titleKo
+        case .english:
+            return PrivacyNoticeContent.titleEn
+        case .japanese:
+            return PrivacyNoticeContent.titleJa
+        }
+    }
+
+    private var privacySummary: String {
+        switch language {
+        case .korean:
+            return PrivacyNoticeContent.summaryKo
+        case .english:
+            return PrivacyNoticeContent.summaryEn
+        case .japanese:
+            return PrivacyNoticeContent.summaryJa
+        }
+    }
+
+    private var privacyDetail: String {
+        switch language {
+        case .korean:
+            return PrivacyNoticeContent.detailKo
+        case .english:
+            return PrivacyNoticeContent.detailEn
+        case .japanese:
+            return PrivacyNoticeContent.detailJa
+        }
+    }
+
+    private var sheetTitle: String {
+        switch language {
+        case .korean:
+            return "동의 안내"
+        case .english:
+            return "Terms of Agree"
+        case .japanese:
+            return "同意案内"
+        }
+    }
+
+    private var agreeButtonTitle: String {
+        switch language {
+        case .korean:
+            return "동의하고 계속하기"
+        case .english:
+            return "Agree and Continue"
+        case .japanese:
+            return "同意して続行"
+        }
+    }
 }
 
 private struct LocationConsentSheet: View {
@@ -184,19 +239,15 @@ private struct LocationConsentSheet: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 18) {
-            Text(language == .korean ? "위치기반 정보 제공 동의" : "Location Consent")
+            Text(consentTitle)
                 .font(.system(size: 22 * fontScale, weight: .bold))
 
-            Text(
-                language == .korean
-                    ? "LALA는 현재 위치를 기반으로 주변 로컬 명소와 맛집을 추천합니다. 동의 후 iOS 위치 권한 허용이 필요합니다."
-                    : "LALA uses your current location to recommend nearby local places. iOS location permission is required."
-            )
+            Text(consentBody)
             .font(.system(size: 15 * fontScale))
             .foregroundStyle(.secondary)
 
             Button(action: onAgree) {
-                Text(language == .korean ? "동의하고 위치 권한 요청" : "Agree and Request Location")
+                Text(consentButtonTitle)
                     .font(.system(size: 17 * fontScale, weight: .bold))
                     .foregroundStyle(.white)
                     .frame(maxWidth: .infinity)
@@ -211,6 +262,39 @@ private struct LocationConsentSheet: View {
         .padding(20)
         .background(Color(.systemBackground))
     }
+
+    private var consentTitle: String {
+        switch language {
+        case .korean:
+            return "위치기반 정보 제공 동의"
+        case .english:
+            return "Location Consent"
+        case .japanese:
+            return "位置情報提供への同意"
+        }
+    }
+
+    private var consentBody: String {
+        switch language {
+        case .korean:
+            return "LALA는 현재 위치를 기반으로 주변 로컬 명소와 맛집을 추천합니다. 동의 후 iOS 위치 권한 허용이 필요합니다."
+        case .english:
+            return "LALA uses your current location to recommend nearby local places. iOS location permission is required."
+        case .japanese:
+            return "LALAは現在地を基準に周辺のローカル名所とグルメをおすすめします。同意後にiOS位置権限が必要です。"
+        }
+    }
+
+    private var consentButtonTitle: String {
+        switch language {
+        case .korean:
+            return "동의하고 위치 권한 요청"
+        case .english:
+            return "Agree and Request Location"
+        case .japanese:
+            return "同意して位置権限を要求"
+        }
+    }
 }
 
 private struct LocationRequiredOverlay: View {
@@ -224,21 +308,17 @@ private struct LocationRequiredOverlay: View {
             Color.black.opacity(0.52).ignoresSafeArea()
 
             VStack(spacing: 14) {
-                Text(language == .korean ? "위치 권한이 필요합니다" : "Location Permission Required")
+                Text(overlayTitle)
                     .font(.system(size: 20 * fontScale, weight: .bold))
                     .multilineTextAlignment(.center)
 
-                Text(
-                    language == .korean
-                        ? "iOS 위치 사용이 꺼져 있어 LALA를 실행할 수 없습니다.\n앱 설정에서 위치 권한을 '사용하는 동안'으로 켜주세요."
-                        : "LALA cannot run while iOS location access is off.\nPlease enable location permission for this app in Settings."
-                )
+                Text(overlayBody)
                 .font(.system(size: 14 * fontScale))
                 .multilineTextAlignment(.center)
                 .foregroundStyle(.secondary)
 
                 Button(action: openSettings) {
-                    Text(language == .korean ? "앱 위치 설정 열기" : "Open App Location Settings")
+                    Text(openSettingsTitle)
                         .font(.system(size: 16 * fontScale, weight: .bold))
                         .foregroundStyle(.white)
                         .frame(maxWidth: .infinity)
@@ -250,7 +330,7 @@ private struct LocationRequiredOverlay: View {
                 }
 
                 Button(action: refresh) {
-                    Text(language == .korean ? "다시 확인" : "Check Again")
+                    Text(retryTitle)
                         .font(.system(size: 15 * fontScale, weight: .semibold))
                 }
             }
@@ -261,6 +341,50 @@ private struct LocationRequiredOverlay: View {
                     .fill(Color(.systemBackground))
             )
             .padding(.horizontal, 24)
+        }
+    }
+
+    private var overlayTitle: String {
+        switch language {
+        case .korean:
+            return "위치 권한이 필요합니다"
+        case .english:
+            return "Location Permission Required"
+        case .japanese:
+            return "位置情報の権限が必要です"
+        }
+    }
+
+    private var overlayBody: String {
+        switch language {
+        case .korean:
+            return "iOS 위치 사용이 꺼져 있어 LALA를 실행할 수 없습니다.\n앱 설정에서 위치 권한을 '사용하는 동안'으로 켜주세요."
+        case .english:
+            return "LALA cannot run while iOS location access is off.\nPlease enable location permission for this app in Settings."
+        case .japanese:
+            return "iOSの位置情報がオフのためLALAを利用できません。\n設定でこのアプリの位置情報権限を有効にしてください。"
+        }
+    }
+
+    private var openSettingsTitle: String {
+        switch language {
+        case .korean:
+            return "앱 위치 설정 열기"
+        case .english:
+            return "Open App Location Settings"
+        case .japanese:
+            return "アプリの位置設定を開く"
+        }
+    }
+
+    private var retryTitle: String {
+        switch language {
+        case .korean:
+            return "다시 확인"
+        case .english:
+            return "Check Again"
+        case .japanese:
+            return "再確認"
         }
     }
 }

--- a/src/frontend/ios/LALA/LALA/Core/MapGuidanceLogic.swift
+++ b/src/frontend/ios/LALA/LALA/Core/MapGuidanceLogic.swift
@@ -7,8 +7,8 @@
 
 import Foundation
 
-struct MapSelectionResult {
-    let selectedPlaceID: UUID?
+struct MapSelectionResult<ID: Equatable> {
+    let selectedPlaceID: ID?
     let subtitle: String
     let shouldSpeak: Bool
     let shouldStopSpeaking: Bool
@@ -16,13 +16,13 @@ struct MapSelectionResult {
 }
 
 enum MapGuidanceLogic {
-    static func reduceSelection(
-        currentSelectedPlaceID: UUID?,
-        tappedPlaceID: UUID,
+    static func reduceSelection<ID: Equatable>(
+        currentSelectedPlaceID: ID?,
+        tappedPlaceID: ID,
         tappedSubtitle: String,
         defaultSubtitle: String,
         isVoiceGuidanceEnabled: Bool
-    ) -> MapSelectionResult {
+    ) -> MapSelectionResult<ID> {
         if currentSelectedPlaceID == tappedPlaceID {
             return MapSelectionResult(
                 selectedPlaceID: nil,

--- a/src/frontend/ios/LALA/LALA/Models/AppLanguage.swift
+++ b/src/frontend/ios/LALA/LALA/Models/AppLanguage.swift
@@ -10,7 +10,6 @@ import Foundation
 enum AppLanguage: String, CaseIterable, Identifiable {
     case korean = "ko"
     case english = "en"
-    case japanese = "ja"
 
     var id: String { rawValue }
 
@@ -18,7 +17,6 @@ enum AppLanguage: String, CaseIterable, Identifiable {
         switch self {
         case .korean: return "한국어"
         case .english: return "English"
-        case .japanese: return "日本語"
         }
     }
 }

--- a/src/frontend/ios/LALA/LALA/Models/AppLanguage.swift
+++ b/src/frontend/ios/LALA/LALA/Models/AppLanguage.swift
@@ -10,6 +10,7 @@ import Foundation
 enum AppLanguage: String, CaseIterable, Identifiable {
     case korean = "ko"
     case english = "en"
+    case japanese = "ja"
 
     var id: String { rawValue }
 
@@ -17,6 +18,7 @@ enum AppLanguage: String, CaseIterable, Identifiable {
         switch self {
         case .korean: return "한국어"
         case .english: return "English"
+        case .japanese: return "日本語"
         }
     }
 }

--- a/src/frontend/ios/LALA/LALA/Models/PlaceRecommendation.swift
+++ b/src/frontend/ios/LALA/LALA/Models/PlaceRecommendation.swift
@@ -11,11 +11,13 @@ import CoreLocation
 enum PlaceCategoryKind: String {
     case attraction
     case restaurant
+    case event
 
     var symbolName: String {
         switch self {
         case .attraction: return "building.columns.fill"
         case .restaurant: return "fork.knife"
+        case .event: return "calendar"
         }
     }
 
@@ -23,6 +25,8 @@ enum PlaceCategoryKind: String {
         switch value.lowercased() {
         case "restaurant":
             return .restaurant
+        case "event":
+            return .event
         case "attraction":
             return .attraction
         default:
@@ -46,6 +50,7 @@ struct PlaceRecommendation: Identifiable {
     let distanceMeters: Int?
     let addressKo: String
     let addressEn: String
+    let imageURL: URL?
 
     init(
         id: String = UUID().uuidString,
@@ -61,7 +66,8 @@ struct PlaceRecommendation: Identifiable {
         coordinate: CLLocationCoordinate2D,
         distanceMeters: Int? = nil,
         addressKo: String = "",
-        addressEn: String = ""
+        addressEn: String = "",
+        imageURL: URL? = nil
     ) {
         self.id = id
         self.nameKo = nameKo
@@ -77,6 +83,7 @@ struct PlaceRecommendation: Identifiable {
         self.distanceMeters = distanceMeters
         self.addressKo = addressKo
         self.addressEn = addressEn
+        self.imageURL = imageURL
     }
 
     func name(in language: AppLanguage) -> String {

--- a/src/frontend/ios/LALA/LALA/Models/PlaceRecommendation.swift
+++ b/src/frontend/ios/LALA/LALA/Models/PlaceRecommendation.swift
@@ -9,6 +9,8 @@ import Foundation
 import CoreLocation
 
 enum PlaceCategoryKind: String {
+    case attraction
+    case restaurant
     case history
     case trekking
     case nightWalk
@@ -16,16 +18,29 @@ enum PlaceCategoryKind: String {
 
     var symbolName: String {
         switch self {
+        case .attraction: return "building.columns.fill"
+        case .restaurant: return "fork.knife"
         case .history: return "building.columns.fill"
         case .trekking: return "figure.hiking"
         case .nightWalk: return "moon.stars.fill"
         case .localEats: return "fork.knife"
         }
     }
+
+    static func fromRemoteCategory(_ value: String) -> PlaceCategoryKind {
+        switch value.lowercased() {
+        case "restaurant":
+            return .restaurant
+        case "attraction":
+            return .attraction
+        default:
+            return .attraction
+        }
+    }
 }
 
 struct PlaceRecommendation: Identifiable {
-    let id = UUID()
+    let id: String
     let nameKo: String
     let nameEn: String
     let categoryKind: PlaceCategoryKind
@@ -36,6 +51,41 @@ struct PlaceRecommendation: Identifiable {
     let guideKo: String
     let guideEn: String
     let coordinate: CLLocationCoordinate2D
+    let distanceMeters: Int?
+    let addressKo: String
+    let addressEn: String
+
+    init(
+        id: String = UUID().uuidString,
+        nameKo: String,
+        nameEn: String,
+        categoryKind: PlaceCategoryKind,
+        categoryKo: String,
+        categoryEn: String,
+        districtKo: String,
+        districtEn: String,
+        guideKo: String,
+        guideEn: String,
+        coordinate: CLLocationCoordinate2D,
+        distanceMeters: Int? = nil,
+        addressKo: String = "",
+        addressEn: String = ""
+    ) {
+        self.id = id
+        self.nameKo = nameKo
+        self.nameEn = nameEn
+        self.categoryKind = categoryKind
+        self.categoryKo = categoryKo
+        self.categoryEn = categoryEn
+        self.districtKo = districtKo
+        self.districtEn = districtEn
+        self.guideKo = guideKo
+        self.guideEn = guideEn
+        self.coordinate = coordinate
+        self.distanceMeters = distanceMeters
+        self.addressKo = addressKo
+        self.addressEn = addressEn
+    }
 
     func name(in language: AppLanguage) -> String {
         language == .korean ? nameKo : nameEn
@@ -52,4 +102,75 @@ struct PlaceRecommendation: Identifiable {
     func guide(in language: AppLanguage) -> String {
         language == .korean ? guideKo : guideEn
     }
+
+    func address(in language: AppLanguage) -> String {
+        language == .korean ? addressKo : addressEn
+    }
+
+    func distanceLabel(in language: AppLanguage) -> String? {
+        guard let distanceMeters else { return nil }
+        if language == .korean {
+            return "\(distanceMeters)m"
+        }
+        return "\(distanceMeters)m"
+    }
+
+    static let fallbackData: [PlaceRecommendation] = [
+        PlaceRecommendation(
+            nameKo: "행주산성",
+            nameEn: "Haengjusanseong Fortress",
+            categoryKind: .history,
+            categoryKo: "역사 명소",
+            categoryEn: "Historic Site",
+            districtKo: "고양시",
+            districtEn: "Goyang",
+            guideKo: "행주산성은 한강 전망과 성곽 산책이 좋은 역사 명소예요. 근처 로컬 식당도 함께 추천해드릴게요.",
+            guideEn: "Haengjusanseong offers scenic fortress walks and river views. I can also recommend nearby local restaurants.",
+            coordinate: CLLocationCoordinate2D(latitude: 37.6001, longitude: 126.8171),
+            addressKo: "경기 고양시 덕양구 행주내동",
+            addressEn: "Haengju-dong, Deogyang-gu, Goyang"
+        ),
+        PlaceRecommendation(
+            nameKo: "남한산성 전통길",
+            nameEn: "Namhansanseong Trail",
+            categoryKind: .trekking,
+            categoryKo: "로컬 트레킹",
+            categoryEn: "Local Trekking",
+            districtKo: "광주시",
+            districtEn: "Gwangju",
+            guideKo: "남한산성 전통길은 숲길과 성곽 풍경을 함께 즐기기 좋은 코스입니다. 초행자에게도 부담이 적어요.",
+            guideEn: "Namhansanseong Trail is a great local course with forest paths and fortress scenery, suitable even for first-time visitors.",
+            coordinate: CLLocationCoordinate2D(latitude: 37.4767, longitude: 127.1830),
+            addressKo: "경기 광주시 남한산성면 산성리",
+            addressEn: "Sanseong-ri, Namhansanseong-myeon, Gwangju"
+        ),
+        PlaceRecommendation(
+            nameKo: "화성행궁 야간거리",
+            nameEn: "Hwaseong Haenggung Night Street",
+            categoryKind: .nightWalk,
+            categoryKo: "야간 산책",
+            categoryEn: "Night Walk",
+            districtKo: "수원시",
+            districtEn: "Suwon",
+            guideKo: "화성행궁 주변은 밤에 조명이 아름다워 산책하기 좋아요. 전통 간식과 골목 맛집도 가까이에 있습니다.",
+            guideEn: "The Hwaseong Haenggung area is ideal for night walks with beautiful lighting, plus local snack spots nearby.",
+            coordinate: CLLocationCoordinate2D(latitude: 37.2810, longitude: 127.0143),
+            addressKo: "경기 수원시 팔달구 정조로 825",
+            addressEn: "825 Jeongjo-ro, Paldal-gu, Suwon"
+        ),
+        PlaceRecommendation(
+            nameKo: "포천 이동갈비 골목",
+            nameEn: "Pocheon Galbi Alley",
+            categoryKind: .localEats,
+            categoryKo: "로컬 맛집",
+            categoryEn: "Local Eats",
+            districtKo: "포천시",
+            districtEn: "Pocheon",
+            guideKo: "포천 이동갈비 골목은 현지인도 자주 찾는 대표 맛집 거리예요. 대기 시간을 줄일 수 있는 매장도 안내해드릴게요.",
+            guideEn: "Pocheon Galbi Alley is a well-known local food street. I can guide you to places with shorter wait times.",
+            coordinate: CLLocationCoordinate2D(latitude: 37.8939, longitude: 127.2006),
+            addressKo: "경기 포천시 이동면 장암리",
+            addressEn: "Jangam-ri, Idong-myeon, Pocheon"
+        )
+    ]
 }

--- a/src/frontend/ios/LALA/LALA/Models/PlaceRecommendation.swift
+++ b/src/frontend/ios/LALA/LALA/Models/PlaceRecommendation.swift
@@ -88,23 +88,48 @@ struct PlaceRecommendation: Identifiable {
     }
 
     func name(in language: AppLanguage) -> String {
-        language == .korean ? nameKo : nameEn
+        switch language {
+        case .korean:
+            return nameKo
+        case .english, .japanese:
+            return nameEn
+        }
     }
 
     func category(in language: AppLanguage) -> String {
-        language == .korean ? categoryKo : categoryEn
+        switch language {
+        case .korean:
+            return categoryKo
+        case .english, .japanese:
+            return categoryEn
+        }
     }
 
     func district(in language: AppLanguage) -> String {
-        language == .korean ? districtKo : districtEn
+        switch language {
+        case .korean:
+            return districtKo
+        case .english, .japanese:
+            return districtEn
+        }
     }
 
     func guide(in language: AppLanguage) -> String {
-        language == .korean ? guideKo : guideEn
+        switch language {
+        case .korean:
+            return guideKo
+        case .english, .japanese:
+            return guideEn
+        }
     }
 
     func address(in language: AppLanguage) -> String {
-        language == .korean ? addressKo : addressEn
+        switch language {
+        case .korean:
+            return addressKo
+        case .english, .japanese:
+            return addressEn
+        }
     }
 
     func distanceLabel(in language: AppLanguage) -> String? {

--- a/src/frontend/ios/LALA/LALA/Models/PlaceRecommendation.swift
+++ b/src/frontend/ios/LALA/LALA/Models/PlaceRecommendation.swift
@@ -83,7 +83,7 @@ struct PlaceRecommendation: Identifiable {
         switch language {
         case .korean:
             return nameKo
-        case .english, .japanese:
+        case .english:
             return nameEn
         }
     }
@@ -92,7 +92,7 @@ struct PlaceRecommendation: Identifiable {
         switch language {
         case .korean:
             return categoryKo
-        case .english, .japanese:
+        case .english:
             return categoryEn
         }
     }
@@ -101,7 +101,7 @@ struct PlaceRecommendation: Identifiable {
         switch language {
         case .korean:
             return districtKo
-        case .english, .japanese:
+        case .english:
             return districtEn
         }
     }
@@ -110,7 +110,7 @@ struct PlaceRecommendation: Identifiable {
         switch language {
         case .korean:
             return guideKo
-        case .english, .japanese:
+        case .english:
             return guideEn
         }
     }
@@ -119,7 +119,7 @@ struct PlaceRecommendation: Identifiable {
         switch language {
         case .korean:
             return addressKo
-        case .english, .japanese:
+        case .english:
             return addressEn
         }
     }

--- a/src/frontend/ios/LALA/LALA/Models/PlaceRecommendation.swift
+++ b/src/frontend/ios/LALA/LALA/Models/PlaceRecommendation.swift
@@ -11,19 +11,11 @@ import CoreLocation
 enum PlaceCategoryKind: String {
     case attraction
     case restaurant
-    case history
-    case trekking
-    case nightWalk
-    case localEats
 
     var symbolName: String {
         switch self {
         case .attraction: return "building.columns.fill"
         case .restaurant: return "fork.knife"
-        case .history: return "building.columns.fill"
-        case .trekking: return "figure.hiking"
-        case .nightWalk: return "moon.stars.fill"
-        case .localEats: return "fork.knife"
         }
     }
 
@@ -140,62 +132,4 @@ struct PlaceRecommendation: Identifiable {
         return "\(distanceMeters)m"
     }
 
-    static let fallbackData: [PlaceRecommendation] = [
-        PlaceRecommendation(
-            nameKo: "행주산성",
-            nameEn: "Haengjusanseong Fortress",
-            categoryKind: .history,
-            categoryKo: "역사 명소",
-            categoryEn: "Historic Site",
-            districtKo: "고양시",
-            districtEn: "Goyang",
-            guideKo: "행주산성은 한강 전망과 성곽 산책이 좋은 역사 명소예요. 근처 로컬 식당도 함께 추천해드릴게요.",
-            guideEn: "Haengjusanseong offers scenic fortress walks and river views. I can also recommend nearby local restaurants.",
-            coordinate: CLLocationCoordinate2D(latitude: 37.6001, longitude: 126.8171),
-            addressKo: "경기 고양시 덕양구 행주내동",
-            addressEn: "Haengju-dong, Deogyang-gu, Goyang"
-        ),
-        PlaceRecommendation(
-            nameKo: "남한산성 전통길",
-            nameEn: "Namhansanseong Trail",
-            categoryKind: .trekking,
-            categoryKo: "로컬 트레킹",
-            categoryEn: "Local Trekking",
-            districtKo: "광주시",
-            districtEn: "Gwangju",
-            guideKo: "남한산성 전통길은 숲길과 성곽 풍경을 함께 즐기기 좋은 코스입니다. 초행자에게도 부담이 적어요.",
-            guideEn: "Namhansanseong Trail is a great local course with forest paths and fortress scenery, suitable even for first-time visitors.",
-            coordinate: CLLocationCoordinate2D(latitude: 37.4767, longitude: 127.1830),
-            addressKo: "경기 광주시 남한산성면 산성리",
-            addressEn: "Sanseong-ri, Namhansanseong-myeon, Gwangju"
-        ),
-        PlaceRecommendation(
-            nameKo: "화성행궁 야간거리",
-            nameEn: "Hwaseong Haenggung Night Street",
-            categoryKind: .nightWalk,
-            categoryKo: "야간 산책",
-            categoryEn: "Night Walk",
-            districtKo: "수원시",
-            districtEn: "Suwon",
-            guideKo: "화성행궁 주변은 밤에 조명이 아름다워 산책하기 좋아요. 전통 간식과 골목 맛집도 가까이에 있습니다.",
-            guideEn: "The Hwaseong Haenggung area is ideal for night walks with beautiful lighting, plus local snack spots nearby.",
-            coordinate: CLLocationCoordinate2D(latitude: 37.2810, longitude: 127.0143),
-            addressKo: "경기 수원시 팔달구 정조로 825",
-            addressEn: "825 Jeongjo-ro, Paldal-gu, Suwon"
-        ),
-        PlaceRecommendation(
-            nameKo: "포천 이동갈비 골목",
-            nameEn: "Pocheon Galbi Alley",
-            categoryKind: .localEats,
-            categoryKo: "로컬 맛집",
-            categoryEn: "Local Eats",
-            districtKo: "포천시",
-            districtEn: "Pocheon",
-            guideKo: "포천 이동갈비 골목은 현지인도 자주 찾는 대표 맛집 거리예요. 대기 시간을 줄일 수 있는 매장도 안내해드릴게요.",
-            guideEn: "Pocheon Galbi Alley is a well-known local food street. I can guide you to places with shorter wait times.",
-            coordinate: CLLocationCoordinate2D(latitude: 37.8939, longitude: 127.2006),
-            addressKo: "경기 포천시 이동면 장암리",
-            addressEn: "Jangam-ri, Idong-myeon, Pocheon"
-        )
-    ]
 }

--- a/src/frontend/ios/LALA/LALA/Models/PlaceRecommendation.swift
+++ b/src/frontend/ios/LALA/LALA/Models/PlaceRecommendation.swift
@@ -133,8 +133,9 @@ struct PlaceRecommendation: Identifiable {
 
     func distanceLabel(in language: AppLanguage) -> String? {
         guard let distanceMeters else { return nil }
-        if language == .korean {
-            return "\(distanceMeters)m"
+        if distanceMeters >= 1_000 {
+            let kilometers = Double(distanceMeters) / 1_000.0
+            return String(format: "%.1fkm", kilometers)
         }
         return "\(distanceMeters)m"
     }

--- a/src/frontend/ios/LALA/LALA/Models/PrivacyNoticeContent.swift
+++ b/src/frontend/ios/LALA/LALA/Models/PrivacyNoticeContent.swift
@@ -12,6 +12,8 @@ struct PrivacyNoticeContent {
     static let summaryKo = "LALA는 경기도 로컬 추천 제공을 위해 위치정보를 포함한 최소한의 개인정보를 수집합니다."
     static let titleEn = "Privacy and Location Consent Notice"
     static let summaryEn = "LALA collects minimal personal data including location to provide local recommendations in Gyeonggi-do."
+    static let titleJa = "個人情報および位置情報利用同意のご案内"
+    static let summaryJa = "LALAは京畿道のローカルおすすめ提供のため、位置情報を含む最小限の個人情報を収集します。"
 
     static let detailKo = """
 제1조(수집 항목)
@@ -57,5 +59,28 @@ As a rule, we do not provide personal data to third parties, unless required by 
 Article 5 (Right to Refuse and Impact)
 You may refuse consent to personal data and location data processing.
 However, because core features are location-based, refusing consent or disabling iOS location permission will restrict app usage.
+"""
+
+    static let detailJa = """
+第1条（収集項目）
+LALAはサービス提供のため、次の情報を収集します。
+- 必須: 端末識別情報、利用ログ、現在地（緯度/経度）
+- 任意: 言語、フォントサイズなどのアプリ設定情報
+
+第2条（利用目的）
+収集した情報は次の目的に限り利用します。
+- ユーザー周辺のローカル名所・グルメ推薦の提供
+- 音声ガイドおよび字幕ベースの案内提供
+- サービス品質向上とエラー分析
+
+第3条（保有および利用期間）
+個人情報は目的達成後、遅滞なく削除します。ただし法令により保存義務がある場合は当該期間保管します。
+
+第4条（第三者提供）
+当社は原則としてユーザーの個人情報を第三者に提供しません。ただし法令上の根拠がある場合、またはユーザー同意がある場合に限り提供します。
+
+第5条（同意拒否の権利と不利益）
+ユーザーは個人情報および位置情報の収集・利用への同意を拒否できます。
+ただし本サービスは位置情報ベースの機能が中核のため、同意拒否またはiOS位置権限の無効化時にはアプリ利用が制限されます。
 """
 }

--- a/src/frontend/ios/LALA/LALA/Models/PrivacyNoticeContent.swift
+++ b/src/frontend/ios/LALA/LALA/Models/PrivacyNoticeContent.swift
@@ -12,8 +12,6 @@ struct PrivacyNoticeContent {
     static let summaryKo = "LALA는 경기도 로컬 추천 제공을 위해 위치정보를 포함한 최소한의 개인정보를 수집합니다."
     static let titleEn = "Privacy and Location Consent Notice"
     static let summaryEn = "LALA collects minimal personal data including location to provide local recommendations in Gyeonggi-do."
-    static let titleJa = "個人情報および位置情報利用同意のご案内"
-    static let summaryJa = "LALAは京畿道のローカルおすすめ提供のため、位置情報を含む最小限の個人情報を収集します。"
 
     static let detailKo = """
 제1조(수집 항목)
@@ -61,26 +59,4 @@ You may refuse consent to personal data and location data processing.
 However, because core features are location-based, refusing consent or disabling iOS location permission will restrict app usage.
 """
 
-    static let detailJa = """
-第1条（収集項目）
-LALAはサービス提供のため、次の情報を収集します。
-- 必須: 端末識別情報、利用ログ、現在地（緯度/経度）
-- 任意: 言語、フォントサイズなどのアプリ設定情報
-
-第2条（利用目的）
-収集した情報は次の目的に限り利用します。
-- ユーザー周辺のローカル名所・グルメ推薦の提供
-- 音声ガイドおよび字幕ベースの案内提供
-- サービス品質向上とエラー分析
-
-第3条（保有および利用期間）
-個人情報は目的達成後、遅滞なく削除します。ただし法令により保存義務がある場合は当該期間保管します。
-
-第4条（第三者提供）
-当社は原則としてユーザーの個人情報を第三者に提供しません。ただし法令上の根拠がある場合、またはユーザー同意がある場合に限り提供します。
-
-第5条（同意拒否の権利と不利益）
-ユーザーは個人情報および位置情報の収集・利用への同意を拒否できます。
-ただし本サービスは位置情報ベースの機能が中核のため、同意拒否またはiOS位置権限の無効化時にはアプリ利用が制限されます。
-"""
 }

--- a/src/frontend/ios/LALA/LALA/Services/MapRemoteService.swift
+++ b/src/frontend/ios/LALA/LALA/Services/MapRemoteService.swift
@@ -21,13 +21,10 @@ enum MapPlaceFilter: String, CaseIterable, Identifiable {
         switch (self, language) {
         case (.all, .korean): return "전체"
         case (.all, .english): return "All"
-        case (.all, .japanese): return "すべて"
         case (.attraction, .korean): return "명소"
         case (.attraction, .english): return "Attractions"
-        case (.attraction, .japanese): return "名所"
         case (.restaurant, .korean): return "맛집"
         case (.restaurant, .english): return "Restaurants"
-        case (.restaurant, .japanese): return "グルメ"
         }
     }
 }

--- a/src/frontend/ios/LALA/LALA/Services/MapRemoteService.swift
+++ b/src/frontend/ios/LALA/LALA/Services/MapRemoteService.swift
@@ -21,10 +21,13 @@ enum MapPlaceFilter: String, CaseIterable, Identifiable {
         switch (self, language) {
         case (.all, .korean): return "전체"
         case (.all, .english): return "All"
+        case (.all, .japanese): return "すべて"
         case (.attraction, .korean): return "명소"
         case (.attraction, .english): return "Attractions"
+        case (.attraction, .japanese): return "名所"
         case (.restaurant, .korean): return "맛집"
         case (.restaurant, .english): return "Restaurants"
+        case (.restaurant, .japanese): return "グルメ"
         }
     }
 }
@@ -40,8 +43,7 @@ protocol MapDataProviding {
     func fetchPlaces(
         center: CLLocationCoordinate2D,
         radiusMeters: Int,
-        category: MapPlaceFilter,
-        language: AppLanguage
+        category: MapPlaceFilter
     ) async throws -> [PlaceRecommendation]
 
     func fetchWeather(at coordinate: CLLocationCoordinate2D) async throws -> WeatherSnapshot
@@ -63,8 +65,7 @@ final class MapRemoteService: MapDataProviding {
     func fetchPlaces(
         center: CLLocationCoordinate2D,
         radiusMeters: Int,
-        category: MapPlaceFilter,
-        language: AppLanguage
+        category: MapPlaceFilter
     ) async throws -> [PlaceRecommendation] {
         let requestURL = try makeURL(
             path: "/api/places",
@@ -80,9 +81,7 @@ final class MapRemoteService: MapDataProviding {
         try validate(response: response)
 
         let decoded = try decoder.decode(RemotePlacesResponse.self, from: data)
-        return decoded.places.map { item in
-            Self.mapPlace(from: item, language: language)
-        }
+        return decoded.places.map(Self.mapPlace(from:))
     }
 
     func fetchWeather(at coordinate: CLLocationCoordinate2D) async throws -> WeatherSnapshot {
@@ -129,7 +128,7 @@ final class MapRemoteService: MapDataProviding {
         }
     }
 
-    private static func mapPlace(from item: RemotePlaceItem, language: AppLanguage) -> PlaceRecommendation {
+    private static func mapPlace(from item: RemotePlaceItem) -> PlaceRecommendation {
         let kind = PlaceCategoryKind.fromRemoteCategory(item.category)
         let categoryKo = item.category == "restaurant" ? "로컬 맛집" : "로컬 명소"
         let categoryEn = item.category == "restaurant" ? "Local Eats" : "Attraction"

--- a/src/frontend/ios/LALA/LALA/Services/MapRemoteService.swift
+++ b/src/frontend/ios/LALA/LALA/Services/MapRemoteService.swift
@@ -237,62 +237,88 @@ final class MapRemoteService: MapDataProviding {
         around center: CLLocationCoordinate2D,
         category: MapPlaceFilter
     ) -> [PlaceRecommendation] {
-        let baseLat = center.latitude
-        let baseLng = center.longitude
-
-        let sample: [PlaceRecommendation] = [
-            PlaceRecommendation(
+        let current = CLLocation(latitude: center.latitude, longitude: center.longitude)
+        let fixedSeeds: [(id: String, nameKo: String, nameEn: String, kind: PlaceCategoryKind, guideKo: String, guideEn: String, lat: Double, lng: Double, addressKo: String, addressEn: String, image: String)] = [
+            (
                 id: "sample-attraction-1",
                 nameKo: "명소 샘플: 행궁동 성곽길",
                 nameEn: "Attraction Sample: Haenggung Fortress Trail",
-                categoryKind: .attraction,
-                categoryKo: "로컬 명소",
-                categoryEn: "Attraction",
-                districtKo: "수원시 팔달구",
-                districtEn: "Paldal-gu, Suwon",
+                kind: .attraction,
                 guideKo: "명소 샘플입니다. 행궁동 성곽길 주변 풍경을 즐겨보세요.",
                 guideEn: "Attraction sample. Enjoy the views around Haenggung trail.",
-                coordinate: CLLocationCoordinate2D(latitude: baseLat + 0.0012, longitude: baseLng - 0.0011),
-                distanceMeters: 180,
+                lat: 37.2817,
+                lng: 127.0150,
                 addressKo: "경기도 수원시 팔달구 행궁로 인근",
                 addressEn: "Near Haenggung-ro, Paldal-gu, Suwon",
-                imageURL: URL(string: "https://picsum.photos/seed/lala-attraction/640/360")
+                image: "https://picsum.photos/seed/lala-attraction/640/360"
             ),
-            PlaceRecommendation(
+            (
                 id: "sample-restaurant-1",
                 nameKo: "맛집 샘플: 팔달 로컬 식당",
                 nameEn: "Restaurant Sample: Paldal Local Diner",
-                categoryKind: .restaurant,
-                categoryKo: "로컬 맛집",
-                categoryEn: "Restaurant",
-                districtKo: "수원시 팔달구",
-                districtEn: "Paldal-gu, Suwon",
+                kind: .restaurant,
                 guideKo: "맛집 샘플입니다. 지역 주민이 자주 찾는 식당이에요.",
                 guideEn: "Restaurant sample. A diner loved by local residents.",
-                coordinate: CLLocationCoordinate2D(latitude: baseLat - 0.0010, longitude: baseLng + 0.0010),
-                distanceMeters: 220,
+                lat: 37.2794,
+                lng: 127.0186,
                 addressKo: "경기도 수원시 팔달구 정조로 인근",
                 addressEn: "Near Jeongjo-ro, Paldal-gu, Suwon",
-                imageURL: URL(string: "https://picsum.photos/seed/lala-restaurant/640/360")
+                image: "https://picsum.photos/seed/lala-restaurant/640/360"
             ),
-            PlaceRecommendation(
+            (
                 id: "sample-event-1",
                 nameKo: "행사 샘플: 화성 야간 프로그램",
                 nameEn: "Event Sample: Hwaseong Night Program",
-                categoryKind: .event,
-                categoryKo: "로컬 행사",
-                categoryEn: "Event",
-                districtKo: "수원시 팔달구",
-                districtEn: "Paldal-gu, Suwon",
+                kind: .event,
                 guideKo: "행사 샘플입니다. 야간 조명과 공연 정보를 확인해보세요.",
                 guideEn: "Event sample. Check out the night lights and performances.",
-                coordinate: CLLocationCoordinate2D(latitude: baseLat + 0.0004, longitude: baseLng + 0.0016),
-                distanceMeters: 260,
+                lat: 37.2829,
+                lng: 127.0174,
                 addressKo: "경기도 수원시 팔달구 신풍로 인근",
                 addressEn: "Near Sinpung-ro, Paldal-gu, Suwon",
-                imageURL: URL(string: "https://picsum.photos/seed/lala-event/640/360")
+                image: "https://picsum.photos/seed/lala-event/640/360"
             )
         ]
+
+        let sample: [PlaceRecommendation] = fixedSeeds.map { seed in
+            let coord = CLLocationCoordinate2D(latitude: seed.lat, longitude: seed.lng)
+            let distance = Int(
+                current.distance(from: CLLocation(latitude: seed.lat, longitude: seed.lng))
+                    .rounded()
+            )
+            let categoryKo: String
+            let categoryEn: String
+            switch seed.kind {
+            case .attraction:
+                categoryKo = "로컬 명소"
+                categoryEn = "Attraction"
+            case .restaurant:
+                categoryKo = "로컬 맛집"
+                categoryEn = "Restaurant"
+            case .event:
+                categoryKo = "로컬 행사"
+                categoryEn = "Event"
+            }
+
+            return PlaceRecommendation(
+                id: seed.id,
+                nameKo: seed.nameKo,
+                nameEn: seed.nameEn,
+                categoryKind: seed.kind,
+                categoryKo: categoryKo,
+                categoryEn: categoryEn,
+                districtKo: "수원시 팔달구",
+                districtEn: "Paldal-gu, Suwon",
+                guideKo: seed.guideKo,
+                guideEn: seed.guideEn,
+                coordinate: coord,
+                distanceMeters: distance,
+                addressKo: seed.addressKo,
+                addressEn: seed.addressEn,
+                imageURL: URL(string: seed.image)
+            )
+        }
+        .sorted { ($0.distanceMeters ?? Int.max) < ($1.distanceMeters ?? Int.max) }
 
         switch category {
         case .all:

--- a/src/frontend/ios/LALA/LALA/Services/MapRemoteService.swift
+++ b/src/frontend/ios/LALA/LALA/Services/MapRemoteService.swift
@@ -1,0 +1,250 @@
+//
+//  MapRemoteService.swift
+//  LALA
+//
+//  Created by Codex on 3/4/26.
+//
+
+import Foundation
+import CoreLocation
+
+enum MapPlaceFilter: String, CaseIterable, Identifiable {
+    case all
+    case attraction
+    case restaurant
+
+    var id: String { rawValue }
+
+    var apiValue: String { rawValue }
+
+    func title(in language: AppLanguage) -> String {
+        switch (self, language) {
+        case (.all, .korean): return "전체"
+        case (.all, .english): return "All"
+        case (.attraction, .korean): return "명소"
+        case (.attraction, .english): return "Attractions"
+        case (.restaurant, .korean): return "맛집"
+        case (.restaurant, .english): return "Restaurants"
+        }
+    }
+}
+
+struct WeatherSnapshot {
+    let symbolName: String
+    let temperatureText: String
+
+    static let placeholder = WeatherSnapshot(symbolName: "cloud.sun.fill", temperatureText: "--°C")
+}
+
+protocol MapDataProviding {
+    func fetchPlaces(
+        center: CLLocationCoordinate2D,
+        radiusMeters: Int,
+        category: MapPlaceFilter,
+        language: AppLanguage
+    ) async throws -> [PlaceRecommendation]
+
+    func fetchWeather(at coordinate: CLLocationCoordinate2D) async throws -> WeatherSnapshot
+}
+
+final class MapRemoteService: MapDataProviding {
+    private let baseURL: URL
+    private let session: URLSession
+    private let decoder = JSONDecoder()
+
+    init(
+        baseURL: URL = AppRuntime.apiBaseURL,
+        session: URLSession = .shared
+    ) {
+        self.baseURL = baseURL
+        self.session = session
+    }
+
+    func fetchPlaces(
+        center: CLLocationCoordinate2D,
+        radiusMeters: Int,
+        category: MapPlaceFilter,
+        language: AppLanguage
+    ) async throws -> [PlaceRecommendation] {
+        let requestURL = try makeURL(
+            path: "/api/places",
+            queryItems: [
+                URLQueryItem(name: "lat", value: String(center.latitude)),
+                URLQueryItem(name: "lng", value: String(center.longitude)),
+                URLQueryItem(name: "radius", value: String(radiusMeters)),
+                URLQueryItem(name: "category", value: category.apiValue)
+            ]
+        )
+
+        let (data, response) = try await session.data(from: requestURL)
+        try validate(response: response)
+
+        let decoded = try decoder.decode(RemotePlacesResponse.self, from: data)
+        return decoded.places.map { item in
+            Self.mapPlace(from: item, language: language)
+        }
+    }
+
+    func fetchWeather(at coordinate: CLLocationCoordinate2D) async throws -> WeatherSnapshot {
+        let requestURL = try makeURL(
+            path: "/api/weather",
+            queryItems: [
+                URLQueryItem(name: "lat", value: String(coordinate.latitude)),
+                URLQueryItem(name: "lng", value: String(coordinate.longitude))
+            ]
+        )
+
+        let (data, response) = try await session.data(from: requestURL)
+        try validate(response: response)
+
+        let decoded = try decoder.decode(RemoteWeatherResponse.self, from: data)
+        return WeatherSnapshot(
+            symbolName: Self.weatherSymbolName(from: decoded.icon),
+            temperatureText: Self.temperatureText(from: decoded.temp)
+        )
+    }
+
+    private func makeURL(path: String, queryItems: [URLQueryItem]) throws -> URL {
+        guard var components = URLComponents(
+            url: baseURL,
+            resolvingAgainstBaseURL: false
+        ) else {
+            throw MapServiceError.invalidBaseURL
+        }
+        components.path = path
+        components.queryItems = queryItems
+
+        guard let url = components.url else {
+            throw MapServiceError.invalidRequestURL
+        }
+        return url
+    }
+
+    private func validate(response: URLResponse) throws {
+        guard let http = response as? HTTPURLResponse else {
+            throw MapServiceError.invalidResponse
+        }
+        guard (200 ... 299).contains(http.statusCode) else {
+            throw MapServiceError.httpStatus(http.statusCode)
+        }
+    }
+
+    private static func mapPlace(from item: RemotePlaceItem, language: AppLanguage) -> PlaceRecommendation {
+        let kind = PlaceCategoryKind.fromRemoteCategory(item.category)
+        let categoryKo = item.category == "restaurant" ? "로컬 맛집" : "로컬 명소"
+        let categoryEn = item.category == "restaurant" ? "Local Eats" : "Attraction"
+        let region = item.region ?? ""
+        let address = item.address ?? ""
+
+        let distanceGuideKo: String
+        let distanceGuideEn: String
+        if let distance = item.distanceM {
+            distanceGuideKo = "현재 위치에서 약 \(distance)m 거리에 있어요."
+            distanceGuideEn = "It is about \(distance)m away from your current location."
+        } else {
+            distanceGuideKo = "현재 위치 근처 추천 장소입니다."
+            distanceGuideEn = "This is a recommended place near your location."
+        }
+
+        let guideKo = "\(item.name) \(distanceGuideKo) \(region) \(address)"
+        let guideEn = "\(item.name). \(distanceGuideEn)"
+
+        return PlaceRecommendation(
+            id: item.id,
+            nameKo: item.name,
+            nameEn: item.name,
+            categoryKind: kind,
+            categoryKo: categoryKo,
+            categoryEn: categoryEn,
+            districtKo: region,
+            districtEn: region,
+            guideKo: guideKo,
+            guideEn: guideEn,
+            coordinate: CLLocationCoordinate2D(latitude: item.lat, longitude: item.lng),
+            distanceMeters: item.distanceM,
+            addressKo: address,
+            addressEn: address
+        )
+    }
+
+    private static func weatherSymbolName(from icon: String) -> String {
+        switch icon {
+        case "☀️": return "sun.max.fill"
+        case "🌧️": return "cloud.rain.fill"
+        case "🌨️": return "cloud.sleet.fill"
+        case "❄️": return "snowflake"
+        case "🌦️": return "cloud.sun.rain.fill"
+        default: return "cloud.sun.fill"
+        }
+    }
+
+    private static func temperatureText(from raw: String) -> String {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.hasSuffix("°C") {
+            return trimmed
+        }
+        return "\(trimmed)°C"
+    }
+}
+
+enum MapServiceError: LocalizedError {
+    case invalidBaseURL
+    case invalidRequestURL
+    case invalidResponse
+    case httpStatus(Int)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidBaseURL:
+            return "API base URL is invalid."
+        case .invalidRequestURL:
+            return "Failed to build request URL."
+        case .invalidResponse:
+            return "Invalid server response."
+        case let .httpStatus(code):
+            return "Server returned HTTP \(code)."
+        }
+    }
+}
+
+enum AppRuntime {
+    static var apiBaseURL: URL {
+        if let custom = Bundle.main.object(forInfoDictionaryKey: "LALA_API_BASE_URL") as? String,
+           let url = URL(string: custom) {
+            return url
+        }
+
+        return URL(string: "http://localhost:5000")!
+    }
+}
+
+private struct RemotePlacesResponse: Decodable {
+    let places: [RemotePlaceItem]
+}
+
+private struct RemotePlaceItem: Decodable {
+    let id: String
+    let name: String
+    let lat: Double
+    let lng: Double
+    let category: String
+    let address: String?
+    let region: String?
+    let distanceM: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case name
+        case lat
+        case lng
+        case category
+        case address
+        case region
+        case distanceM = "distance_m"
+    }
+}
+
+private struct RemoteWeatherResponse: Decodable {
+    let temp: String
+    let icon: String
+}

--- a/src/frontend/ios/LALA/LALA/Services/MapRemoteService.swift
+++ b/src/frontend/ios/LALA/LALA/Services/MapRemoteService.swift
@@ -67,6 +67,10 @@ final class MapRemoteService: MapDataProviding {
         radiusMeters: Int,
         category: MapPlaceFilter
     ) async throws -> [PlaceRecommendation] {
+        guard baseURL != nil else {
+            return Self.fallbackPlaces(around: center, category: category)
+        }
+
         let requestURL = try makeURL(
             path: "/api/places",
             queryItems: [
@@ -77,14 +81,23 @@ final class MapRemoteService: MapDataProviding {
             ]
         )
 
-        let (data, response) = try await session.data(from: requestURL)
-        try validate(response: response)
+        do {
+            let (data, response) = try await session.data(from: requestURL)
+            try validate(response: response)
 
-        let decoded = try decoder.decode(RemotePlacesResponse.self, from: data)
-        return decoded.places.map(Self.mapPlace(from:))
+            let decoded = try decoder.decode(RemotePlacesResponse.self, from: data)
+            let mapped = decoded.places.map(Self.mapPlace(from:))
+            return mapped.isEmpty ? Self.fallbackPlaces(around: center, category: category) : mapped
+        } catch {
+            return Self.fallbackPlaces(around: center, category: category)
+        }
     }
 
     func fetchWeather(at coordinate: CLLocationCoordinate2D) async throws -> WeatherSnapshot {
+        guard baseURL != nil else {
+            return WeatherSnapshot(symbolName: "cloud.sun.fill", temperatureText: "13°C")
+        }
+
         let requestURL = try makeURL(
             path: "/api/weather",
             queryItems: [
@@ -93,14 +106,18 @@ final class MapRemoteService: MapDataProviding {
             ]
         )
 
-        let (data, response) = try await session.data(from: requestURL)
-        try validate(response: response)
+        do {
+            let (data, response) = try await session.data(from: requestURL)
+            try validate(response: response)
 
-        let decoded = try decoder.decode(RemoteWeatherResponse.self, from: data)
-        return WeatherSnapshot(
-            symbolName: Self.weatherSymbolName(from: decoded.icon),
-            temperatureText: Self.temperatureText(from: decoded.temp)
-        )
+            let decoded = try decoder.decode(RemoteWeatherResponse.self, from: data)
+            return WeatherSnapshot(
+                symbolName: Self.weatherSymbolName(from: decoded.icon),
+                temperatureText: Self.temperatureText(from: decoded.temp)
+            )
+        } catch {
+            return WeatherSnapshot(symbolName: "cloud.sun.fill", temperatureText: "13°C")
+        }
     }
 
     private func makeURL(path: String, queryItems: [URLQueryItem]) throws -> URL {
@@ -214,6 +231,79 @@ final class MapRemoteService: MapDataProviding {
             return trimmed
         }
         return "\(trimmed)°C"
+    }
+
+    private static func fallbackPlaces(
+        around center: CLLocationCoordinate2D,
+        category: MapPlaceFilter
+    ) -> [PlaceRecommendation] {
+        let baseLat = center.latitude
+        let baseLng = center.longitude
+
+        let sample: [PlaceRecommendation] = [
+            PlaceRecommendation(
+                id: "sample-attraction-1",
+                nameKo: "명소 샘플: 행궁동 성곽길",
+                nameEn: "Attraction Sample: Haenggung Fortress Trail",
+                categoryKind: .attraction,
+                categoryKo: "로컬 명소",
+                categoryEn: "Attraction",
+                districtKo: "수원시 팔달구",
+                districtEn: "Paldal-gu, Suwon",
+                guideKo: "명소 샘플입니다. 행궁동 성곽길 주변 풍경을 즐겨보세요.",
+                guideEn: "Attraction sample. Enjoy the views around Haenggung trail.",
+                coordinate: CLLocationCoordinate2D(latitude: baseLat + 0.0012, longitude: baseLng - 0.0011),
+                distanceMeters: 180,
+                addressKo: "경기도 수원시 팔달구 행궁로 인근",
+                addressEn: "Near Haenggung-ro, Paldal-gu, Suwon",
+                imageURL: URL(string: "https://picsum.photos/seed/lala-attraction/640/360")
+            ),
+            PlaceRecommendation(
+                id: "sample-restaurant-1",
+                nameKo: "맛집 샘플: 팔달 로컬 식당",
+                nameEn: "Restaurant Sample: Paldal Local Diner",
+                categoryKind: .restaurant,
+                categoryKo: "로컬 맛집",
+                categoryEn: "Restaurant",
+                districtKo: "수원시 팔달구",
+                districtEn: "Paldal-gu, Suwon",
+                guideKo: "맛집 샘플입니다. 지역 주민이 자주 찾는 식당이에요.",
+                guideEn: "Restaurant sample. A diner loved by local residents.",
+                coordinate: CLLocationCoordinate2D(latitude: baseLat - 0.0010, longitude: baseLng + 0.0010),
+                distanceMeters: 220,
+                addressKo: "경기도 수원시 팔달구 정조로 인근",
+                addressEn: "Near Jeongjo-ro, Paldal-gu, Suwon",
+                imageURL: URL(string: "https://picsum.photos/seed/lala-restaurant/640/360")
+            ),
+            PlaceRecommendation(
+                id: "sample-event-1",
+                nameKo: "행사 샘플: 화성 야간 프로그램",
+                nameEn: "Event Sample: Hwaseong Night Program",
+                categoryKind: .event,
+                categoryKo: "로컬 행사",
+                categoryEn: "Event",
+                districtKo: "수원시 팔달구",
+                districtEn: "Paldal-gu, Suwon",
+                guideKo: "행사 샘플입니다. 야간 조명과 공연 정보를 확인해보세요.",
+                guideEn: "Event sample. Check out the night lights and performances.",
+                coordinate: CLLocationCoordinate2D(latitude: baseLat + 0.0004, longitude: baseLng + 0.0016),
+                distanceMeters: 260,
+                addressKo: "경기도 수원시 팔달구 신풍로 인근",
+                addressEn: "Near Sinpung-ro, Paldal-gu, Suwon",
+                imageURL: URL(string: "https://picsum.photos/seed/lala-event/640/360")
+            )
+        ]
+
+        switch category {
+        case .all:
+            return sample
+        case .attraction:
+            return sample.filter { $0.categoryKind == .attraction }
+        case .restaurant:
+            return sample.filter { $0.categoryKind == .restaurant }
+        case .event:
+            return sample.filter { $0.categoryKind == .event }
+        }
     }
 }
 

--- a/src/frontend/ios/LALA/LALA/Services/MapRemoteService.swift
+++ b/src/frontend/ios/LALA/LALA/Services/MapRemoteService.swift
@@ -50,12 +50,12 @@ protocol MapDataProviding {
 }
 
 final class MapRemoteService: MapDataProviding {
-    private let baseURL: URL
+    private let baseURL: URL?
     private let session: URLSession
     private let decoder = JSONDecoder()
 
     init(
-        baseURL: URL = AppRuntime.apiBaseURL,
+        baseURL: URL? = AppRuntime.apiBaseURL,
         session: URLSession = .shared
     ) {
         self.baseURL = baseURL
@@ -104,13 +104,32 @@ final class MapRemoteService: MapDataProviding {
     }
 
     private func makeURL(path: String, queryItems: [URLQueryItem]) throws -> URL {
+        guard let baseURL else {
+            throw MapServiceError.missingBaseURL
+        }
+        if let host = baseURL.host?.lowercased(),
+           host == "localhost" || host == "127.0.0.1" {
+            throw MapServiceError.localhostNotAllowed
+        }
+
         guard var components = URLComponents(
             url: baseURL,
             resolvingAgainstBaseURL: false
         ) else {
             throw MapServiceError.invalidBaseURL
         }
-        components.path = path
+
+        let endpointPath = path.hasPrefix("/") ? String(path.dropFirst()) : path
+        let normalizedBasePath = components.path
+            .split(separator: "/")
+            .map(String.init)
+            .joined(separator: "/")
+
+        if normalizedBasePath.isEmpty {
+            components.path = "/\(endpointPath)"
+        } else {
+            components.path = "/\(normalizedBasePath)/\(endpointPath)"
+        }
         components.queryItems = queryItems
 
         guard let url = components.url else {
@@ -187,6 +206,8 @@ final class MapRemoteService: MapDataProviding {
 }
 
 enum MapServiceError: LocalizedError {
+    case missingBaseURL
+    case localhostNotAllowed
     case invalidBaseURL
     case invalidRequestURL
     case invalidResponse
@@ -194,6 +215,10 @@ enum MapServiceError: LocalizedError {
 
     var errorDescription: String? {
         switch self {
+        case .missingBaseURL:
+            return "API base URL is missing."
+        case .localhostNotAllowed:
+            return "localhost is not allowed for API base URL."
         case .invalidBaseURL:
             return "API base URL is invalid."
         case .invalidRequestURL:
@@ -207,13 +232,48 @@ enum MapServiceError: LocalizedError {
 }
 
 enum AppRuntime {
-    static var apiBaseURL: URL {
-        if let custom = Bundle.main.object(forInfoDictionaryKey: "LALA_API_BASE_URL") as? String,
+    static var apiBaseURL: URL? {
+        if let custom = loadBaseURLFromAppConfig(named: "AppConfig.local"),
            let url = URL(string: custom) {
             return url
         }
 
-        return URL(string: "http://localhost:5000")!
+        if let custom = loadBaseURLFromAppConfig(named: "AppConfig"),
+           let url = URL(string: custom) {
+            return url
+        }
+
+        if let custom = Bundle.main.object(forInfoDictionaryKey: "LALA_API_BASE_URL") as? String,
+           !custom.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+           let url = URL(string: custom) {
+            return url
+        }
+
+        return nil
+    }
+
+    private static func loadBaseURLFromAppConfig(named resourceName: String) -> String? {
+        let candidates: [(String?, String)] = [
+            ("Config", resourceName),
+            (nil, resourceName)
+        ]
+
+        for candidate in candidates {
+            if let url = Bundle.main.url(
+                forResource: candidate.1,
+                withExtension: "plist",
+                subdirectory: candidate.0
+            ),
+            let dictionary = NSDictionary(contentsOf: url) as? [String: Any],
+            let value = dictionary["API_BASE_URL"] as? String {
+                let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+                if !trimmed.isEmpty {
+                    return trimmed
+                }
+            }
+        }
+
+        return nil
     }
 }
 

--- a/src/frontend/ios/LALA/LALA/Services/MapRemoteService.swift
+++ b/src/frontend/ios/LALA/LALA/Services/MapRemoteService.swift
@@ -12,6 +12,7 @@ enum MapPlaceFilter: String, CaseIterable, Identifiable {
     case all
     case attraction
     case restaurant
+    case event
 
     var id: String { rawValue }
 
@@ -25,6 +26,8 @@ enum MapPlaceFilter: String, CaseIterable, Identifiable {
         case (.attraction, .english): return "Attractions"
         case (.restaurant, .korean): return "맛집"
         case (.restaurant, .english): return "Restaurants"
+        case (.event, .korean): return "행사"
+        case (.event, .english): return "Events"
         }
     }
 }
@@ -146,8 +149,19 @@ final class MapRemoteService: MapDataProviding {
 
     private static func mapPlace(from item: RemotePlaceItem) -> PlaceRecommendation {
         let kind = PlaceCategoryKind.fromRemoteCategory(item.category)
-        let categoryKo = item.category == "restaurant" ? "로컬 맛집" : "로컬 명소"
-        let categoryEn = item.category == "restaurant" ? "Local Eats" : "Attraction"
+        let categoryKo: String
+        let categoryEn: String
+        switch kind {
+        case .attraction:
+            categoryKo = "로컬 명소"
+            categoryEn = "Attraction"
+        case .restaurant:
+            categoryKo = "로컬 맛집"
+            categoryEn = "Restaurant"
+        case .event:
+            categoryKo = "로컬 행사"
+            categoryEn = "Event"
+        }
         let region = item.region ?? ""
         let address = item.address ?? ""
 
@@ -178,7 +192,8 @@ final class MapRemoteService: MapDataProviding {
             coordinate: CLLocationCoordinate2D(latitude: item.lat, longitude: item.lng),
             distanceMeters: item.distanceM,
             addressKo: address,
-            addressEn: address
+            addressEn: address,
+            imageURL: item.imageURL.flatMap(URL.init(string:))
         )
     }
 
@@ -287,6 +302,7 @@ private struct RemotePlaceItem: Decodable {
     let address: String?
     let region: String?
     let distanceM: Int?
+    let imageURL: String?
 
     enum CodingKeys: String, CodingKey {
         case id
@@ -297,6 +313,7 @@ private struct RemotePlaceItem: Decodable {
         case address
         case region
         case distanceM = "distance_m"
+        case imageURL = "image_url"
     }
 }
 

--- a/src/frontend/ios/LALA/LALA/ViewModels/AppViewModel.swift
+++ b/src/frontend/ios/LALA/LALA/ViewModels/AppViewModel.swift
@@ -102,7 +102,13 @@ final class AppViewModel: ObservableObject {
         guard let preferred = Locale.preferredLanguages.first?.lowercased() else {
             return .english
         }
-        return preferred.hasPrefix("ko") ? .korean : .english
+        if preferred.hasPrefix("ko") {
+            return .korean
+        }
+        if preferred.hasPrefix("ja") {
+            return .japanese
+        }
+        return .english
     }
 }
 

--- a/src/frontend/ios/LALA/LALA/ViewModels/AppViewModel.swift
+++ b/src/frontend/ios/LALA/LALA/ViewModels/AppViewModel.swift
@@ -105,9 +105,6 @@ final class AppViewModel: ObservableObject {
         if preferred.hasPrefix("ko") {
             return .korean
         }
-        if preferred.hasPrefix("ja") {
-            return .japanese
-        }
         return .english
     }
 }

--- a/src/frontend/ios/LALA/LALA/ViewModels/MainMapViewModel.swift
+++ b/src/frontend/ios/LALA/LALA/ViewModels/MainMapViewModel.swift
@@ -90,8 +90,6 @@ final class MainMapViewModel: NSObject, ObservableObject, CLLocationManagerDeleg
             return "현재 날씨 \(weatherValue)"
         case .english:
             return "Current weather \(weatherValue)"
-        case .japanese:
-            return "現在の天気 \(weatherValue)"
         }
     }
 
@@ -105,8 +103,6 @@ final class MainMapViewModel: NSObject, ObservableObject, CLLocationManagerDeleg
                 return "주변 추천 장소가 없습니다."
             case .english:
                 return "No recommended places found nearby."
-            case .japanese:
-                return "周辺におすすめスポットが見つかりません。"
             }
         case .networkError:
             switch language {
@@ -114,8 +110,6 @@ final class MainMapViewModel: NSObject, ObservableObject, CLLocationManagerDeleg
                 return "데이터를 불러오지 못했습니다. API 서버 설정 또는 네트워크를 확인하세요."
             case .english:
                 return "Failed to load data. Check API server configuration or network."
-            case .japanese:
-                return "データを読み込めません。APIサーバー設定またはネットワークを確認してください。"
             }
         }
     }
@@ -131,8 +125,6 @@ final class MainMapViewModel: NSObject, ObservableObject, CLLocationManagerDeleg
             return "추천 이유"
         case .english:
             return "Why This Place"
-        case .japanese:
-            return "おすすめ理由"
         }
     }
 
@@ -153,11 +145,6 @@ final class MainMapViewModel: NSObject, ObservableObject, CLLocationManagerDeleg
                 return "A highly rated \(category.lowercased()) spot around \(district). \(address)"
             }
             return "A recommended \(category.lowercased()) spot about \(distance) from your current location. \(address)"
-        case .japanese:
-            if distance.isEmpty {
-                return "\(district)で人気の\(category)スポットです。\(address)"
-            }
-            return "現在地から約\(distance)の\(category)おすすめスポットです。\(address)"
         }
     }
 
@@ -167,8 +154,6 @@ final class MainMapViewModel: NSObject, ObservableObject, CLLocationManagerDeleg
             return "음성 안내: 지금 위치 기준 15분 거리의 로컬 맛집과 산책 코스를 안내해드릴게요."
         case .english:
             return "Voice guide: I can guide you to local food spots and walks within 15 minutes."
-        case .japanese:
-            return "音声ガイド: 現在地から15分圏内のローカル名所とグルメを案内します。"
         }
     }
 
@@ -178,8 +163,6 @@ final class MainMapViewModel: NSObject, ObservableObject, CLLocationManagerDeleg
             return "음성 안내가 꺼져 있습니다. 하단 버튼을 눌러 다시 시작하세요."
         case .english:
             return "Voice guidance is off. Tap the bottom button to resume."
-        case .japanese:
-            return "音声ガイドはオフです。下のボタンを押して再開してください。"
         }
     }
 
@@ -195,8 +178,6 @@ final class MainMapViewModel: NSObject, ObservableObject, CLLocationManagerDeleg
             voiceCode = "ko-KR"
         case .english:
             voiceCode = "en-US"
-        case .japanese:
-            voiceCode = "ja-JP"
         }
         utterance.voice = AVSpeechSynthesisVoice(language: voiceCode)
         utterance.rate = 0.5

--- a/src/frontend/ios/LALA/LALA/ViewModels/MainMapViewModel.swift
+++ b/src/frontend/ios/LALA/LALA/ViewModels/MainMapViewModel.swift
@@ -16,6 +16,7 @@ import SwiftUI
 final class MainMapViewModel: NSObject, ObservableObject, CLLocationManagerDelegate {
     @Published var region: MKCoordinateRegion
     @Published var isVoiceGuidanceEnabled = true
+    @Published var isAutoDocentEnabled = false
     @Published var subtitle = ""
     @Published var weatherSymbol = WeatherSnapshot.placeholder.symbolName
     @Published var weatherValue = WeatherSnapshot.placeholder.temperatureText
@@ -30,12 +31,13 @@ final class MainMapViewModel: NSObject, ObservableObject, CLLocationManagerDeleg
     private let locationManager = CLLocationManager()
     private let mapDataProvider: MapDataProviding
     private let searchRadiusMeters = 3_000
+    private let autoDocentTriggerRadiusMeters: CLLocationDistance = 100
     private let defaultMapSpan = MKCoordinateSpan(latitudeDelta: 0.01, longitudeDelta: 0.01)
     private var hasAppliedInitialUserFocus = false
     private var isAppLocationConsentEnabled = false
     private var activeLanguage: AppLanguage = .korean
     private var reloadTask: Task<Void, Never>?
-    private var debounceTask: Task<Void, Never>?
+    private var lastAutoGuidedPlaceID: String?
 
     private let initialRegion = MKCoordinateRegion(
         center: CLLocationCoordinate2D(latitude: 36.35, longitude: 127.9),
@@ -60,7 +62,7 @@ final class MainMapViewModel: NSObject, ObservableObject, CLLocationManagerDeleg
 
     func updateLanguage(_ language: AppLanguage) {
         refreshSubtitle(for: language)
-        reloadMapData(around: region.center)
+        reloadMapData()
     }
 
     func toggleVoiceGuidance(for language: AppLanguage) {
@@ -69,12 +71,25 @@ final class MainMapViewModel: NSObject, ObservableObject, CLLocationManagerDeleg
             speechSynthesizer.stopSpeaking(at: .immediate)
         }
         refreshSubtitle(for: language)
+        if isAutoDocentEnabled {
+            runAutoDocentIfNeeded(language: language, forceAnnounce: false)
+        }
+    }
+
+    func toggleAutoDocentMode(for language: AppLanguage) {
+        activeLanguage = language
+        isAutoDocentEnabled.toggle()
+        if isAutoDocentEnabled {
+            runAutoDocentIfNeeded(language: language, forceAnnounce: true)
+        } else {
+            lastAutoGuidedPlaceID = nil
+        }
     }
 
     func selectFilter(_ filter: MapPlaceFilter) {
         guard selectedFilter != filter else { return }
         selectedFilter = filter
-        reloadMapData(around: region.center)
+        reloadMapData()
     }
 
     func handlePlaceTap(_ place: PlaceRecommendation, language: AppLanguage) {
@@ -206,6 +221,9 @@ final class MainMapViewModel: NSObject, ObservableObject, CLLocationManagerDeleg
         if result.shouldSpeak {
             speak(result.subtitle, language: language)
         }
+        if let selected = result.selectedPlaceID {
+            lastAutoGuidedPlaceID = selected
+        }
     }
 
     private func defaultSubtitle(for language: AppLanguage) -> String {
@@ -229,25 +247,17 @@ final class MainMapViewModel: NSObject, ObservableObject, CLLocationManagerDeleg
     func updateRegionFromMap(_ candidate: MKCoordinateRegion) {
         let clamped = clampRegion(candidate)
         guard !isNearlyEqual(region, clamped) else { return }
-        Task { @MainActor [clamped] in
-            self.region = clamped
-            self.scheduleDebouncedReload(center: clamped.center)
+        // Avoid mutating ObservableObject synchronously during SwiftUI Map update passes.
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            guard !isNearlyEqual(region, clamped) else { return }
+            region = clamped
         }
     }
 
-    private func scheduleDebouncedReload(center: CLLocationCoordinate2D) {
+    private func reloadMapData() {
         guard isAppLocationConsentEnabled else { return }
-
-        debounceTask?.cancel()
-        debounceTask = Task { [weak self] in
-            try? await Task.sleep(nanoseconds: 550_000_000)
-            guard !Task.isCancelled else { return }
-            self?.reloadMapData(around: center)
-        }
-    }
-
-    private func reloadMapData(around center: CLLocationCoordinate2D) {
-        guard isAppLocationConsentEnabled else { return }
+        let anchor = userCoordinate ?? region.center
 
         reloadTask?.cancel()
         reloadTask = Task { [weak self] in
@@ -257,11 +267,11 @@ final class MainMapViewModel: NSObject, ObservableObject, CLLocationManagerDeleg
 
             do {
                 async let loadedPlaces = mapDataProvider.fetchPlaces(
-                    center: center,
+                    center: anchor,
                     radiusMeters: searchRadiusMeters,
                     category: selectedFilter
                 )
-                async let weather = mapDataProvider.fetchWeather(at: center)
+                async let weather = mapDataProvider.fetchWeather(at: anchor)
 
                 let (placesResult, weatherResult) = try await (loadedPlaces, weather)
                 guard !Task.isCancelled else { return }
@@ -290,10 +300,12 @@ final class MainMapViewModel: NSObject, ObservableObject, CLLocationManagerDeleg
                 speechSynthesizer.stopSpeaking(at: .immediate)
             }
         }
+
+        runAutoDocentIfNeeded(language: activeLanguage, forceAnnounce: false)
     }
 
     func retryLoadingPlaces() {
-        reloadMapData(around: region.center)
+        reloadMapData()
     }
 
     func configureLocationUpdates(consentEnabled: Bool) {
@@ -310,7 +322,7 @@ final class MainMapViewModel: NSObject, ObservableObject, CLLocationManagerDeleg
         case .authorizedWhenInUse, .authorizedAlways:
             locationManager.startUpdatingLocation()
             locationManager.requestLocation()
-            reloadMapData(around: userCoordinate ?? region.center)
+            reloadMapData()
         case .denied, .restricted:
             locationManager.stopUpdatingLocation()
         @unknown default:
@@ -336,7 +348,7 @@ final class MainMapViewModel: NSObject, ObservableObject, CLLocationManagerDeleg
         } else {
             region = clamped
         }
-        reloadMapData(around: clamped.center)
+        reloadMapData()
     }
 
     func centerOnPlace(_ place: PlaceRecommendation, animated: Bool) {
@@ -375,13 +387,46 @@ final class MainMapViewModel: NSObject, ObservableObject, CLLocationManagerDeleg
             return
         }
 
-        if places.isEmpty {
-            reloadMapData(around: latest.coordinate)
-        }
+        reloadMapData()
+        runAutoDocentIfNeeded(language: activeLanguage, forceAnnounce: false)
     }
 
     func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
         // Keep UI responsive even if a one-shot location request fails.
+    }
+
+    private func runAutoDocentIfNeeded(language: AppLanguage, forceAnnounce: Bool) {
+        guard isAutoDocentEnabled, let userCoordinate, !places.isEmpty else { return }
+        guard let nearest = nearestPlace(to: userCoordinate) else { return }
+        guard nearest.distance <= autoDocentTriggerRadiusMeters else {
+            // Keep silent outside trigger radius and reset so entering range can announce.
+            lastAutoGuidedPlaceID = nil
+            return
+        }
+        guard forceAnnounce || nearest.place.id != lastAutoGuidedPlaceID else { return }
+
+        selectedPlaceID = nearest.place.id
+        subtitle = nearest.place.guide(in: language)
+        lastAutoGuidedPlaceID = nearest.place.id
+
+        if isVoiceGuidanceEnabled {
+            speak(subtitle, language: language)
+        }
+    }
+
+    private func nearestPlace(to userCoordinate: CLLocationCoordinate2D) -> (place: PlaceRecommendation, distance: CLLocationDistance)? {
+        places
+            .map { place in
+                (place: place, distance: distance(from: userCoordinate, to: place.coordinate))
+            }
+            .min { lhs, rhs in
+                lhs.distance < rhs.distance
+            }
+    }
+
+    private func distance(from lhs: CLLocationCoordinate2D, to rhs: CLLocationCoordinate2D) -> CLLocationDistance {
+        CLLocation(latitude: lhs.latitude, longitude: lhs.longitude)
+            .distance(from: CLLocation(latitude: rhs.latitude, longitude: rhs.longitude))
     }
 }
 

--- a/src/frontend/ios/LALA/LALA/ViewModels/MainMapViewModel.swift
+++ b/src/frontend/ios/LALA/LALA/ViewModels/MainMapViewModel.swift
@@ -41,8 +41,8 @@ final class MainMapViewModel: NSObject, ObservableObject, CLLocationManagerDeleg
         span: MKCoordinateSpan(latitudeDelta: 7.0, longitudeDelta: 8.0)
     )
 
-    init(mapDataProvider: MapDataProviding = MapRemoteService()) {
-        self.mapDataProvider = mapDataProvider
+    init(mapDataProvider: MapDataProviding? = nil) {
+        self.mapDataProvider = mapDataProvider ?? MapRemoteService()
         region = initialRegion
         places = PlaceRecommendation.fallbackData
         super.init()
@@ -85,39 +85,101 @@ final class MainMapViewModel: NSObject, ObservableObject, CLLocationManagerDeleg
     }
 
     func weatherA11yText(for language: AppLanguage) -> String {
-        language == .korean
-            ? "현재 날씨 \(weatherValue)"
-            : "Current weather \(weatherValue)"
+        switch language {
+        case .korean:
+            return "현재 날씨 \(weatherValue)"
+        case .english:
+            return "Current weather \(weatherValue)"
+        case .japanese:
+            return "現在の天気 \(weatherValue)"
+        }
     }
 
     func statusMessage(for language: AppLanguage) -> String? {
         mapStatusMessage.flatMap { _ in
             if places.isEmpty {
-                return language == .korean
-                    ? "주변 추천 장소가 없습니다."
-                    : "No recommended places found nearby."
+                switch language {
+                case .korean:
+                    return "주변 추천 장소가 없습니다."
+                case .english:
+                    return "No recommended places found nearby."
+                case .japanese:
+                    return "周辺におすすめスポットが見つかりません。"
+                }
             }
 
-            return language == .korean
-                ? "네트워크 문제로 임시 추천 목록을 표시 중입니다."
-                : "Showing fallback recommendations due to a network issue."
+            switch language {
+            case .korean:
+                return "네트워크 문제로 임시 추천 목록을 표시 중입니다."
+            case .english:
+                return "Showing fallback recommendations due to a network issue."
+            case .japanese:
+                return "ネットワークの問題により、代替おすすめを表示しています。"
+            }
+        }
+    }
+
+    var selectedPlace: PlaceRecommendation? {
+        guard let selectedPlaceID else { return nil }
+        return places.first(where: { $0.id == selectedPlaceID })
+    }
+
+    func recommendationTitle(for language: AppLanguage) -> String {
+        switch language {
+        case .korean:
+            return "추천 이유"
+        case .english:
+            return "Why This Place"
+        case .japanese:
+            return "おすすめ理由"
+        }
+    }
+
+    func recommendationReason(for place: PlaceRecommendation, language: AppLanguage) -> String {
+        let category = place.category(in: language)
+        let district = place.district(in: language)
+        let address = place.address(in: language)
+        let distance = place.distanceLabel(in: language) ?? ""
+
+        switch language {
+        case .korean:
+            if distance.isEmpty {
+                return "\(district)의 \(category) 카테고리에서 인기가 높은 장소예요. \(address)"
+            }
+            return "현재 위치에서 약 \(distance) 거리의 \(category) 추천 장소예요. \(address)"
+        case .english:
+            if distance.isEmpty {
+                return "A highly rated \(category.lowercased()) spot around \(district). \(address)"
+            }
+            return "A recommended \(category.lowercased()) spot about \(distance) from your current location. \(address)"
+        case .japanese:
+            if distance.isEmpty {
+                return "\(district)で人気の\(category)スポットです。\(address)"
+            }
+            return "現在地から約\(distance)の\(category)おすすめスポットです。\(address)"
         }
     }
 
     private func voiceOnSubtitle(for language: AppLanguage) -> String {
-        if language == .korean {
+        switch language {
+        case .korean:
             return "음성 안내: 지금 위치 기준 15분 거리의 로컬 맛집과 산책 코스를 안내해드릴게요."
+        case .english:
+            return "Voice guide: I can guide you to local food spots and walks within 15 minutes."
+        case .japanese:
+            return "音声ガイド: 現在地から15分圏内のローカル名所とグルメを案内します。"
         }
-
-        return "Voice guide: I can guide you to local food spots and walks within 15 minutes."
     }
 
     private func voiceOffSubtitle(for language: AppLanguage) -> String {
-        if language == .korean {
+        switch language {
+        case .korean:
             return "음성 안내가 꺼져 있습니다. 하단 버튼을 눌러 다시 시작하세요."
+        case .english:
+            return "Voice guidance is off. Tap the bottom button to resume."
+        case .japanese:
+            return "音声ガイドはオフです。下のボタンを押して再開してください。"
         }
-
-        return "Voice guidance is off. Tap the bottom button to resume."
     }
 
     private func speak(_ text: String, language: AppLanguage) {
@@ -126,7 +188,16 @@ final class MainMapViewModel: NSObject, ObservableObject, CLLocationManagerDeleg
         }
 
         let utterance = AVSpeechUtterance(string: text)
-        utterance.voice = AVSpeechSynthesisVoice(language: language == .korean ? "ko-KR" : "en-US")
+        let voiceCode: String
+        switch language {
+        case .korean:
+            voiceCode = "ko-KR"
+        case .english:
+            voiceCode = "en-US"
+        case .japanese:
+            voiceCode = "ja-JP"
+        }
+        utterance.voice = AVSpeechSynthesisVoice(language: voiceCode)
         utterance.rate = 0.5
         speechSynthesizer.speak(utterance)
     }
@@ -188,7 +259,7 @@ final class MainMapViewModel: NSObject, ObservableObject, CLLocationManagerDeleg
         debounceTask = Task { [weak self] in
             try? await Task.sleep(nanoseconds: 550_000_000)
             guard !Task.isCancelled else { return }
-            await self?.reloadMapData(around: center)
+            self?.reloadMapData(around: center)
         }
     }
 
@@ -205,8 +276,7 @@ final class MainMapViewModel: NSObject, ObservableObject, CLLocationManagerDeleg
                 async let loadedPlaces = mapDataProvider.fetchPlaces(
                     center: center,
                     radiusMeters: searchRadiusMeters,
-                    category: selectedFilter,
-                    language: activeLanguage
+                    category: selectedFilter
                 )
                 async let weather = mapDataProvider.fetchWeather(at: center)
 

--- a/src/frontend/ios/LALA/LALA/ViewModels/MainMapViewModel.swift
+++ b/src/frontend/ios/LALA/LALA/ViewModels/MainMapViewModel.swift
@@ -30,6 +30,7 @@ final class MainMapViewModel: NSObject, ObservableObject, CLLocationManagerDeleg
     private let locationManager = CLLocationManager()
     private let mapDataProvider: MapDataProviding
     private let searchRadiusMeters = 3_000
+    private let defaultMapSpan = MKCoordinateSpan(latitudeDelta: 0.01, longitudeDelta: 0.01)
     private var hasAppliedInitialUserFocus = false
     private var isAppLocationConsentEnabled = false
     private var activeLanguage: AppLanguage = .korean
@@ -325,7 +326,7 @@ final class MainMapViewModel: NSObject, ObservableObject, CLLocationManagerDeleg
 
         let focused = MKCoordinateRegion(
             center: coordinate,
-            span: MKCoordinateSpan(latitudeDelta: 0.002, longitudeDelta: 0.002)
+            span: defaultMapSpan
         )
         let clamped = clampRegion(focused)
         if animated {
@@ -341,7 +342,7 @@ final class MainMapViewModel: NSObject, ObservableObject, CLLocationManagerDeleg
     func centerOnPlace(_ place: PlaceRecommendation, animated: Bool) {
         let focused = MKCoordinateRegion(
             center: place.coordinate,
-            span: MKCoordinateSpan(latitudeDelta: 0.01, longitudeDelta: 0.01)
+            span: defaultMapSpan
         )
         let clamped = clampRegion(focused)
         if animated {

--- a/src/frontend/ios/LALA/LALA/ViewModels/MainMapViewModel.swift
+++ b/src/frontend/ios/LALA/LALA/ViewModels/MainMapViewModel.swift
@@ -24,7 +24,7 @@ final class MainMapViewModel: NSObject, ObservableObject, CLLocationManagerDeleg
     @Published private(set) var places: [PlaceRecommendation]
     @Published var selectedFilter: MapPlaceFilter = .all
     @Published private(set) var isLoadingPlaces = false
-    @Published private(set) var mapStatusMessage: String?
+    @Published private(set) var mapStatus: MapStatus = .none
 
     private let speechSynthesizer = AVSpeechSynthesizer()
     private let locationManager = CLLocationManager()
@@ -44,7 +44,7 @@ final class MainMapViewModel: NSObject, ObservableObject, CLLocationManagerDeleg
     init(mapDataProvider: MapDataProviding? = nil) {
         self.mapDataProvider = mapDataProvider ?? MapRemoteService()
         region = initialRegion
-        places = PlaceRecommendation.fallbackData
+        places = []
         super.init()
         locationManager.delegate = self
         locationManager.desiredAccuracy = kCLLocationAccuracyHundredMeters
@@ -96,25 +96,26 @@ final class MainMapViewModel: NSObject, ObservableObject, CLLocationManagerDeleg
     }
 
     func statusMessage(for language: AppLanguage) -> String? {
-        mapStatusMessage.flatMap { _ in
-            if places.isEmpty {
-                switch language {
-                case .korean:
-                    return "주변 추천 장소가 없습니다."
-                case .english:
-                    return "No recommended places found nearby."
-                case .japanese:
-                    return "周辺におすすめスポットが見つかりません。"
-                }
-            }
-
+        switch mapStatus {
+        case .none:
+            return nil
+        case .noResults:
             switch language {
             case .korean:
-                return "네트워크 문제로 임시 추천 목록을 표시 중입니다."
+                return "주변 추천 장소가 없습니다."
             case .english:
-                return "Showing fallback recommendations due to a network issue."
+                return "No recommended places found nearby."
             case .japanese:
-                return "ネットワークの問題により、代替おすすめを表示しています。"
+                return "周辺におすすめスポットが見つかりません。"
+            }
+        case .networkError:
+            switch language {
+            case .korean:
+                return "데이터를 불러오지 못했습니다. API 서버 설정 또는 네트워크를 확인하세요."
+            case .english:
+                return "Failed to load data. Check API server configuration or network."
+            case .japanese:
+                return "データを読み込めません。APIサーバー設定またはネットワークを確認してください。"
             }
         }
     }
@@ -270,7 +271,7 @@ final class MainMapViewModel: NSObject, ObservableObject, CLLocationManagerDeleg
         reloadTask = Task { [weak self] in
             guard let self else { return }
             isLoadingPlaces = true
-            mapStatusMessage = nil
+            mapStatus = .none
 
             do {
                 async let loadedPlaces = mapDataProvider.fetchPlaces(
@@ -290,19 +291,14 @@ final class MainMapViewModel: NSObject, ObservableObject, CLLocationManagerDeleg
             } catch {
                 guard !Task.isCancelled else { return }
                 isLoadingPlaces = false
-                mapStatusMessage = error.localizedDescription
-
-                // Keep existing places when available. If empty, show static fallback.
-                if places.isEmpty {
-                    places = PlaceRecommendation.fallbackData
-                }
+                mapStatus = .networkError
             }
         }
     }
 
     private func applyPlaces(_ loadedPlaces: [PlaceRecommendation]) {
         places = loadedPlaces
-        mapStatusMessage = loadedPlaces.isEmpty ? "NO_RESULTS" : nil
+        mapStatus = loadedPlaces.isEmpty ? .noResults : .none
 
         guard let selectedPlaceID else { return }
         if !loadedPlaces.contains(where: { $0.id == selectedPlaceID }) {
@@ -405,4 +401,10 @@ final class MainMapViewModel: NSObject, ObservableObject, CLLocationManagerDeleg
     func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
         // Keep UI responsive even if a one-shot location request fails.
     }
+}
+
+enum MapStatus {
+    case none
+    case noResults
+    case networkError
 }

--- a/src/frontend/ios/LALA/LALA/ViewModels/MainMapViewModel.swift
+++ b/src/frontend/ios/LALA/LALA/ViewModels/MainMapViewModel.swift
@@ -17,85 +17,49 @@ final class MainMapViewModel: NSObject, ObservableObject, CLLocationManagerDeleg
     @Published var region: MKCoordinateRegion
     @Published var isVoiceGuidanceEnabled = true
     @Published var subtitle = ""
-    @Published var weatherSymbol = "cloud.sun.fill"
-    @Published var weatherValue = "13°C"
-    @Published var selectedPlaceID: UUID?
+    @Published var weatherSymbol = WeatherSnapshot.placeholder.symbolName
+    @Published var weatherValue = WeatherSnapshot.placeholder.temperatureText
+    @Published var selectedPlaceID: String?
     @Published private(set) var userCoordinate: CLLocationCoordinate2D?
+    @Published private(set) var places: [PlaceRecommendation]
+    @Published var selectedFilter: MapPlaceFilter = .all
+    @Published private(set) var isLoadingPlaces = false
+    @Published private(set) var mapStatusMessage: String?
 
-    let places: [PlaceRecommendation]
     private let speechSynthesizer = AVSpeechSynthesizer()
     private let locationManager = CLLocationManager()
+    private let mapDataProvider: MapDataProviding
+    private let searchRadiusMeters = 3_000
     private var hasAppliedInitialUserFocus = false
     private var isAppLocationConsentEnabled = false
+    private var activeLanguage: AppLanguage = .korean
+    private var reloadTask: Task<Void, Never>?
+    private var debounceTask: Task<Void, Never>?
 
     private let initialRegion = MKCoordinateRegion(
         center: CLLocationCoordinate2D(latitude: 36.35, longitude: 127.9),
         span: MKCoordinateSpan(latitudeDelta: 7.0, longitudeDelta: 8.0)
     )
 
-    override init() {
+    init(mapDataProvider: MapDataProviding = MapRemoteService()) {
+        self.mapDataProvider = mapDataProvider
         region = initialRegion
-
-        places = [
-            PlaceRecommendation(
-                nameKo: "행주산성",
-                nameEn: "Haengjusanseong Fortress",
-                categoryKind: .history,
-                categoryKo: "역사 명소",
-                categoryEn: "Historic Site",
-                districtKo: "고양시",
-                districtEn: "Goyang",
-                guideKo: "행주산성은 한강 전망과 성곽 산책이 좋은 역사 명소예요. 근처 로컬 식당도 함께 추천해드릴게요.",
-                guideEn: "Haengjusanseong offers scenic fortress walks and river views. I can also recommend nearby local restaurants.",
-                coordinate: CLLocationCoordinate2D(latitude: 37.6001, longitude: 126.8171)
-            ),
-            PlaceRecommendation(
-                nameKo: "남한산성 전통길",
-                nameEn: "Namhansanseong Trail",
-                categoryKind: .trekking,
-                categoryKo: "로컬 트레킹",
-                categoryEn: "Local Trekking",
-                districtKo: "광주시",
-                districtEn: "Gwangju",
-                guideKo: "남한산성 전통길은 숲길과 성곽 풍경을 함께 즐기기 좋은 코스입니다. 초행자에게도 부담이 적어요.",
-                guideEn: "Namhansanseong Trail is a great local course with forest paths and fortress scenery, suitable even for first-time visitors.",
-                coordinate: CLLocationCoordinate2D(latitude: 37.4767, longitude: 127.1830)
-            ),
-            PlaceRecommendation(
-                nameKo: "화성행궁 야간거리",
-                nameEn: "Hwaseong Haenggung Night Street",
-                categoryKind: .nightWalk,
-                categoryKo: "야간 산책",
-                categoryEn: "Night Walk",
-                districtKo: "수원시",
-                districtEn: "Suwon",
-                guideKo: "화성행궁 주변은 밤에 조명이 아름다워 산책하기 좋아요. 전통 간식과 골목 맛집도 가까이에 있습니다.",
-                guideEn: "The Hwaseong Haenggung area is ideal for night walks with beautiful lighting, plus local snack spots nearby.",
-                coordinate: CLLocationCoordinate2D(latitude: 37.2810, longitude: 127.0143)
-            ),
-            PlaceRecommendation(
-                nameKo: "포천 이동갈비 골목",
-                nameEn: "Pocheon Galbi Alley",
-                categoryKind: .localEats,
-                categoryKo: "로컬 맛집",
-                categoryEn: "Local Eats",
-                districtKo: "포천시",
-                districtEn: "Pocheon",
-                guideKo: "포천 이동갈비 골목은 현지인도 자주 찾는 대표 맛집 거리예요. 대기 시간을 줄일 수 있는 매장도 안내해드릴게요.",
-                guideEn: "Pocheon Galbi Alley is a well-known local food street. I can guide you to places with shorter wait times.",
-                coordinate: CLLocationCoordinate2D(latitude: 37.8939, longitude: 127.2006)
-            )
-        ]
-
+        places = PlaceRecommendation.fallbackData
         super.init()
         locationManager.delegate = self
         locationManager.desiredAccuracy = kCLLocationAccuracyHundredMeters
     }
 
     func refreshSubtitle(for language: AppLanguage) {
+        activeLanguage = language
         subtitle = isVoiceGuidanceEnabled
             ? voiceOnSubtitle(for: language)
             : voiceOffSubtitle(for: language)
+    }
+
+    func updateLanguage(_ language: AppLanguage) {
+        refreshSubtitle(for: language)
+        reloadMapData(around: region.center)
     }
 
     func toggleVoiceGuidance(for language: AppLanguage) {
@@ -104,6 +68,12 @@ final class MainMapViewModel: NSObject, ObservableObject, CLLocationManagerDeleg
             speechSynthesizer.stopSpeaking(at: .immediate)
         }
         refreshSubtitle(for: language)
+    }
+
+    func selectFilter(_ filter: MapPlaceFilter) {
+        guard selectedFilter != filter else { return }
+        selectedFilter = filter
+        reloadMapData(around: region.center)
     }
 
     func handlePlaceTap(_ place: PlaceRecommendation, language: AppLanguage) {
@@ -118,6 +88,20 @@ final class MainMapViewModel: NSObject, ObservableObject, CLLocationManagerDeleg
         language == .korean
             ? "현재 날씨 \(weatherValue)"
             : "Current weather \(weatherValue)"
+    }
+
+    func statusMessage(for language: AppLanguage) -> String? {
+        mapStatusMessage.flatMap { _ in
+            if places.isEmpty {
+                return language == .korean
+                    ? "주변 추천 장소가 없습니다."
+                    : "No recommended places found nearby."
+            }
+
+            return language == .korean
+                ? "네트워크 문제로 임시 추천 목록을 표시 중입니다."
+                : "Showing fallback recommendations due to a network issue."
+        }
     }
 
     private func voiceOnSubtitle(for language: AppLanguage) -> String {
@@ -193,7 +177,75 @@ final class MainMapViewModel: NSObject, ObservableObject, CLLocationManagerDeleg
         guard !isNearlyEqual(region, clamped) else { return }
         Task { @MainActor [clamped] in
             self.region = clamped
+            self.scheduleDebouncedReload(center: clamped.center)
         }
+    }
+
+    private func scheduleDebouncedReload(center: CLLocationCoordinate2D) {
+        guard isAppLocationConsentEnabled else { return }
+
+        debounceTask?.cancel()
+        debounceTask = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: 550_000_000)
+            guard !Task.isCancelled else { return }
+            await self?.reloadMapData(around: center)
+        }
+    }
+
+    private func reloadMapData(around center: CLLocationCoordinate2D) {
+        guard isAppLocationConsentEnabled else { return }
+
+        reloadTask?.cancel()
+        reloadTask = Task { [weak self] in
+            guard let self else { return }
+            isLoadingPlaces = true
+            mapStatusMessage = nil
+
+            do {
+                async let loadedPlaces = mapDataProvider.fetchPlaces(
+                    center: center,
+                    radiusMeters: searchRadiusMeters,
+                    category: selectedFilter,
+                    language: activeLanguage
+                )
+                async let weather = mapDataProvider.fetchWeather(at: center)
+
+                let (placesResult, weatherResult) = try await (loadedPlaces, weather)
+                guard !Task.isCancelled else { return }
+
+                applyPlaces(placesResult)
+                weatherSymbol = weatherResult.symbolName
+                weatherValue = weatherResult.temperatureText
+                isLoadingPlaces = false
+            } catch {
+                guard !Task.isCancelled else { return }
+                isLoadingPlaces = false
+                mapStatusMessage = error.localizedDescription
+
+                // Keep existing places when available. If empty, show static fallback.
+                if places.isEmpty {
+                    places = PlaceRecommendation.fallbackData
+                }
+            }
+        }
+    }
+
+    private func applyPlaces(_ loadedPlaces: [PlaceRecommendation]) {
+        places = loadedPlaces
+        mapStatusMessage = loadedPlaces.isEmpty ? "NO_RESULTS" : nil
+
+        guard let selectedPlaceID else { return }
+        if !loadedPlaces.contains(where: { $0.id == selectedPlaceID }) {
+            self.selectedPlaceID = nil
+            subtitle = defaultSubtitle(for: activeLanguage)
+            if speechSynthesizer.isSpeaking {
+                speechSynthesizer.stopSpeaking(at: .immediate)
+            }
+        }
+    }
+
+    func retryLoadingPlaces() {
+        reloadMapData(around: region.center)
     }
 
     func configureLocationUpdates(consentEnabled: Bool) {
@@ -210,6 +262,7 @@ final class MainMapViewModel: NSObject, ObservableObject, CLLocationManagerDeleg
         case .authorizedWhenInUse, .authorizedAlways:
             locationManager.startUpdatingLocation()
             locationManager.requestLocation()
+            reloadMapData(around: userCoordinate ?? region.center)
         case .denied, .restricted:
             locationManager.stopUpdatingLocation()
         @unknown default:
@@ -235,6 +288,7 @@ final class MainMapViewModel: NSObject, ObservableObject, CLLocationManagerDeleg
         } else {
             region = clamped
         }
+        reloadMapData(around: clamped.center)
     }
 
     func centerOnPlace(_ place: PlaceRecommendation, animated: Bool) {
@@ -270,6 +324,11 @@ final class MainMapViewModel: NSObject, ObservableObject, CLLocationManagerDeleg
         if !hasAppliedInitialUserFocus {
             hasAppliedInitialUserFocus = true
             centerOnUserLocation(animated: false)
+            return
+        }
+
+        if places.isEmpty {
+            reloadMapData(around: latest.coordinate)
         }
     }
 

--- a/src/frontend/ios/LALA/LALA/ViewModels/MainMapViewModel.swift
+++ b/src/frontend/ios/LALA/LALA/ViewModels/MainMapViewModel.swift
@@ -57,9 +57,7 @@ final class MainMapViewModel: NSObject, ObservableObject, CLLocationManagerDeleg
 
     func refreshSubtitle(for language: AppLanguage) {
         activeLanguage = language
-        subtitle = isVoiceGuidanceEnabled
-            ? voiceOnSubtitle(for: language)
-            : voiceOffSubtitle(for: language)
+        subtitle = voiceOnSubtitle(for: language)
     }
 
     func updateLanguage(_ language: AppLanguage) {
@@ -72,7 +70,10 @@ final class MainMapViewModel: NSObject, ObservableObject, CLLocationManagerDeleg
         if !isVoiceGuidanceEnabled, speechSynthesizer.isSpeaking {
             speechSynthesizer.stopSpeaking(at: .immediate)
         }
-        refreshSubtitle(for: language)
+        // Do not replace current caption with a "voice off" notice.
+        if isVoiceGuidanceEnabled, selectedPlaceID == nil {
+            subtitle = voiceOnSubtitle(for: language)
+        }
         if isAutoDocentEnabled {
             runAutoDocentIfNeeded(language: language, forceAnnounce: false)
         }
@@ -108,16 +109,13 @@ final class MainMapViewModel: NSObject, ObservableObject, CLLocationManagerDeleg
         hiddenMoreInfoPlaceID = nil
         subtitle = place.guide(in: language)
         lastAutoGuidedPlaceID = place.id
+        moreInfoEligiblePlaceID = place.id
         centerOnPlace(place, animated: true)
 
         if isVoiceGuidanceEnabled {
-            moreInfoEligiblePlaceID = place.id
             speak(subtitle, language: language)
-        } else {
-            if speechSynthesizer.isSpeaking {
-                speechSynthesizer.stopSpeaking(at: .immediate)
-            }
-            moreInfoEligiblePlaceID = nil
+        } else if speechSynthesizer.isSpeaking {
+            speechSynthesizer.stopSpeaking(at: .immediate)
         }
     }
 
@@ -195,8 +193,7 @@ final class MainMapViewModel: NSObject, ObservableObject, CLLocationManagerDeleg
     }
 
     func canPlayMoreInfo(for placeID: String) -> Bool {
-        isVoiceGuidanceEnabled &&
-            moreInfoEligiblePlaceID == placeID &&
+        moreInfoEligiblePlaceID == placeID &&
             hiddenMoreInfoPlaceID != placeID
     }
 
@@ -207,6 +204,12 @@ final class MainMapViewModel: NSObject, ObservableObject, CLLocationManagerDeleg
         subtitle = narration
         hiddenMoreInfoPlaceID = place.id
         moreInfoEligiblePlaceID = nil
+        guard isVoiceGuidanceEnabled else {
+            if speechSynthesizer.isSpeaking {
+                speechSynthesizer.stopSpeaking(at: .immediate)
+            }
+            return
+        }
         speak(narration, language: language)
     }
 
@@ -216,15 +219,6 @@ final class MainMapViewModel: NSObject, ObservableObject, CLLocationManagerDeleg
             return "음성 안내: 지금 위치 기준 15분 거리의 로컬 맛집과 산책 코스를 안내해드릴게요."
         case .english:
             return "Voice guide: I can guide you to local food spots and walks within 15 minutes."
-        }
-    }
-
-    private func voiceOffSubtitle(for language: AppLanguage) -> String {
-        switch language {
-        case .korean:
-            return "음성 안내가 꺼져 있습니다. 하단 버튼을 눌러 다시 시작하세요."
-        case .english:
-            return "Voice guidance is off. Tap the bottom button to resume."
         }
     }
 
@@ -259,9 +253,11 @@ final class MainMapViewModel: NSObject, ObservableObject, CLLocationManagerDeleg
         subtitle = result.subtitle
 
         if result.selectedPlaceID == nil {
+            hiddenMoreInfoPlaceID = nil
             moreInfoEligiblePlaceID = nil
         } else if result.selectedPlaceID != hiddenMoreInfoPlaceID {
             hiddenMoreInfoPlaceID = nil
+            moreInfoEligiblePlaceID = result.selectedPlaceID
         }
 
         if result.shouldStopSpeaking, speechSynthesizer.isSpeaking {
@@ -282,7 +278,7 @@ final class MainMapViewModel: NSObject, ObservableObject, CLLocationManagerDeleg
     }
 
     private func defaultSubtitle(for language: AppLanguage) -> String {
-        isVoiceGuidanceEnabled ? voiceOnSubtitle(for: language) : voiceOffSubtitle(for: language)
+        voiceOnSubtitle(for: language)
     }
 
     func clampRegion(_ candidate: MKCoordinateRegion) -> MKCoordinateRegion {
@@ -466,12 +462,10 @@ final class MainMapViewModel: NSObject, ObservableObject, CLLocationManagerDeleg
         hiddenMoreInfoPlaceID = nil
         subtitle = nearest.place.guide(in: language)
         lastAutoGuidedPlaceID = nearest.place.id
+        moreInfoEligiblePlaceID = nearest.place.id
 
         if isVoiceGuidanceEnabled {
-            moreInfoEligiblePlaceID = nearest.place.id
             speak(subtitle, language: language)
-        } else {
-            moreInfoEligiblePlaceID = nil
         }
     }
 

--- a/src/frontend/ios/LALA/LALA/ViewModels/MainMapViewModel.swift
+++ b/src/frontend/ios/LALA/LALA/ViewModels/MainMapViewModel.swift
@@ -26,6 +26,7 @@ final class MainMapViewModel: NSObject, ObservableObject, CLLocationManagerDeleg
     @Published var selectedFilter: MapPlaceFilter = .all
     @Published private(set) var isLoadingPlaces = false
     @Published private(set) var mapStatus: MapStatus = .none
+    @Published private(set) var moreInfoEligiblePlaceID: String?
 
     private let speechSynthesizer = AVSpeechSynthesizer()
     private let locationManager = CLLocationManager()
@@ -38,6 +39,7 @@ final class MainMapViewModel: NSObject, ObservableObject, CLLocationManagerDeleg
     private var activeLanguage: AppLanguage = .korean
     private var reloadTask: Task<Void, Never>?
     private var lastAutoGuidedPlaceID: String?
+    private var hiddenMoreInfoPlaceID: String?
 
     private let initialRegion = MKCoordinateRegion(
         center: CLLocationCoordinate2D(latitude: 36.35, longitude: 127.9),
@@ -98,6 +100,25 @@ final class MainMapViewModel: NSObject, ObservableObject, CLLocationManagerDeleg
 
     func handleMapPinTap(_ place: PlaceRecommendation, language: AppLanguage) {
         applySelection(for: place, language: language)
+    }
+
+    func activatePlaceForDetail(_ place: PlaceRecommendation, language: AppLanguage) {
+        activeLanguage = language
+        selectedPlaceID = place.id
+        hiddenMoreInfoPlaceID = nil
+        subtitle = place.guide(in: language)
+        lastAutoGuidedPlaceID = place.id
+        centerOnPlace(place, animated: true)
+
+        if isVoiceGuidanceEnabled {
+            moreInfoEligiblePlaceID = place.id
+            speak(subtitle, language: language)
+        } else {
+            if speechSynthesizer.isSpeaking {
+                speechSynthesizer.stopSpeaking(at: .immediate)
+            }
+            moreInfoEligiblePlaceID = nil
+        }
     }
 
     func weatherA11yText(for language: AppLanguage) -> String {
@@ -164,6 +185,31 @@ final class MainMapViewModel: NSObject, ObservableObject, CLLocationManagerDeleg
         }
     }
 
+    func moreInfoButtonTitle(for language: AppLanguage) -> String {
+        switch language {
+        case .korean:
+            return "정보 더 듣기"
+        case .english:
+            return "Hear More Info"
+        }
+    }
+
+    func canPlayMoreInfo(for placeID: String) -> Bool {
+        isVoiceGuidanceEnabled &&
+            moreInfoEligiblePlaceID == placeID &&
+            hiddenMoreInfoPlaceID != placeID
+    }
+
+    func playMoreInfo(for place: PlaceRecommendation, language: AppLanguage) {
+        guard canPlayMoreInfo(for: place.id) else { return }
+        activeLanguage = language
+        let narration = buildMoreInfoNarration(for: place, language: language)
+        subtitle = narration
+        hiddenMoreInfoPlaceID = place.id
+        moreInfoEligiblePlaceID = nil
+        speak(narration, language: language)
+    }
+
     private func voiceOnSubtitle(for language: AppLanguage) -> String {
         switch language {
         case .korean:
@@ -212,6 +258,12 @@ final class MainMapViewModel: NSObject, ObservableObject, CLLocationManagerDeleg
         selectedPlaceID = result.selectedPlaceID
         subtitle = result.subtitle
 
+        if result.selectedPlaceID == nil {
+            moreInfoEligiblePlaceID = nil
+        } else if result.selectedPlaceID != hiddenMoreInfoPlaceID {
+            hiddenMoreInfoPlaceID = nil
+        }
+
         if result.shouldStopSpeaking, speechSynthesizer.isSpeaking {
             speechSynthesizer.stopSpeaking(at: .immediate)
         }
@@ -219,7 +271,10 @@ final class MainMapViewModel: NSObject, ObservableObject, CLLocationManagerDeleg
             centerOnPlace(place, animated: true)
         }
         if result.shouldSpeak {
+            moreInfoEligiblePlaceID = place.id
             speak(result.subtitle, language: language)
+        } else if result.selectedPlaceID != place.id {
+            moreInfoEligiblePlaceID = nil
         }
         if let selected = result.selectedPlaceID {
             lastAutoGuidedPlaceID = selected
@@ -295,6 +350,8 @@ final class MainMapViewModel: NSObject, ObservableObject, CLLocationManagerDeleg
         guard let selectedPlaceID else { return }
         if !loadedPlaces.contains(where: { $0.id == selectedPlaceID }) {
             self.selectedPlaceID = nil
+            hiddenMoreInfoPlaceID = nil
+            moreInfoEligiblePlaceID = nil
             subtitle = defaultSubtitle(for: activeLanguage)
             if speechSynthesizer.isSpeaking {
                 speechSynthesizer.stopSpeaking(at: .immediate)
@@ -406,11 +463,30 @@ final class MainMapViewModel: NSObject, ObservableObject, CLLocationManagerDeleg
         guard forceAnnounce || nearest.place.id != lastAutoGuidedPlaceID else { return }
 
         selectedPlaceID = nearest.place.id
+        hiddenMoreInfoPlaceID = nil
         subtitle = nearest.place.guide(in: language)
         lastAutoGuidedPlaceID = nearest.place.id
 
         if isVoiceGuidanceEnabled {
+            moreInfoEligiblePlaceID = nearest.place.id
             speak(subtitle, language: language)
+        } else {
+            moreInfoEligiblePlaceID = nil
+        }
+    }
+
+    private func buildMoreInfoNarration(for place: PlaceRecommendation, language: AppLanguage) -> String {
+        let name = place.name(in: language)
+        let category = place.category(in: language)
+        let district = place.district(in: language)
+        let address = place.address(in: language)
+        let reason = recommendationReason(for: place, language: language)
+
+        switch language {
+        case .korean:
+            return "\(name)은(는) \(district) 지역의 \(category) 추천 장소입니다. 주소는 \(address)입니다. \(reason) 방문 전 운영 시간과 현장 상황을 함께 확인해 주세요."
+        case .english:
+            return "\(name) is a recommended \(category.lowercased()) spot in \(district). The address is \(address). \(reason) Please also check opening hours and local conditions before you visit."
         }
     }
 

--- a/src/frontend/ios/LALA/LALA/ViewModels/OnboardingViewModel.swift
+++ b/src/frontend/ios/LALA/LALA/ViewModels/OnboardingViewModel.swift
@@ -16,8 +16,6 @@ final class OnboardingViewModel: ObservableObject {
             return "경기도 로컬을 진짜처럼"
         case .english:
             return "Real Local Gyeonggi"
-        case .japanese:
-            return "京畿道ローカルを本物らしく"
         }
     }
 
@@ -27,8 +25,6 @@ final class OnboardingViewModel: ObservableObject {
             return "외국인을 위한 로컬 명소, 맛집, 문화 추천 서비스"
         case .english:
             return "Authentic local spots, food, and culture picks for travelers."
-        case .japanese:
-            return "旅行者向けのローカル名所・グルメ・文化推薦サービス"
         }
     }
 
@@ -46,12 +42,6 @@ final class OnboardingViewModel: ObservableObject {
                 "Voice guidance with subtitles for on-the-go use",
                 "Language, font size, and location consent controls"
             ]
-        case .japanese:
-            return [
-                "地図上で周辺のおすすめをすぐに確認",
-                "移動中も音声ガイドと字幕で快適に利用",
-                "言語・文字サイズ・位置情報同意をいつでも変更可能"
-            ]
         }
     }
 
@@ -61,8 +51,6 @@ final class OnboardingViewModel: ObservableObject {
             return "시작하기"
         case .english:
             return "Get Started"
-        case .japanese:
-            return "はじめる"
         }
     }
 }

--- a/src/frontend/ios/LALA/LALA/ViewModels/OnboardingViewModel.swift
+++ b/src/frontend/ios/LALA/LALA/ViewModels/OnboardingViewModel.swift
@@ -11,32 +11,58 @@ import Combine
 @MainActor
 final class OnboardingViewModel: ObservableObject {
     func title(in language: AppLanguage) -> String {
-        language == .korean ? "경기도 로컬을 진짜처럼" : "Real Local Gyeonggi"
+        switch language {
+        case .korean:
+            return "경기도 로컬을 진짜처럼"
+        case .english:
+            return "Real Local Gyeonggi"
+        case .japanese:
+            return "京畿道ローカルを本物らしく"
+        }
     }
 
     func subtitle(in language: AppLanguage) -> String {
-        language == .korean
-            ? "외국인을 위한 로컬 명소, 맛집, 문화 추천 서비스"
-            : "Authentic local spots, food, and culture picks for travelers."
+        switch language {
+        case .korean:
+            return "외국인을 위한 로컬 명소, 맛집, 문화 추천 서비스"
+        case .english:
+            return "Authentic local spots, food, and culture picks for travelers."
+        case .japanese:
+            return "旅行者向けのローカル名所・グルメ・文化推薦サービス"
+        }
     }
 
     func bullets(in language: AppLanguage) -> [String] {
-        if language == .korean {
+        switch language {
+        case .korean:
             return [
                 "지도에서 바로 주변 추천을 확인",
                 "음성 안내와 자막으로 이동 중에도 편하게",
                 "언어/글꼴/위치 동의 설정을 언제든 변경 가능"
             ]
+        case .english:
+            return [
+                "Explore nearby local picks directly on the map",
+                "Voice guidance with subtitles for on-the-go use",
+                "Language, font size, and location consent controls"
+            ]
+        case .japanese:
+            return [
+                "地図上で周辺のおすすめをすぐに確認",
+                "移動中も音声ガイドと字幕で快適に利用",
+                "言語・文字サイズ・位置情報同意をいつでも変更可能"
+            ]
         }
-
-        return [
-            "Explore nearby local picks directly on the map",
-            "Voice guidance with subtitles for on-the-go use",
-            "Language, font size, and location consent controls"
-        ]
     }
 
     func ctaTitle(in language: AppLanguage) -> String {
-        language == .korean ? "시작하기" : "Get Started"
+        switch language {
+        case .korean:
+            return "시작하기"
+        case .english:
+            return "Get Started"
+        case .japanese:
+            return "はじめる"
+        }
     }
 }

--- a/src/frontend/ios/LALA/LALA/ViewModels/SettingsViewModel.swift
+++ b/src/frontend/ios/LALA/LALA/ViewModels/SettingsViewModel.swift
@@ -35,8 +35,6 @@ final class SettingsViewModel: ObservableObject {
             return "설정"
         case .english:
             return "Settings"
-        case .japanese:
-            return "設定"
         }
     }
 
@@ -46,8 +44,6 @@ final class SettingsViewModel: ObservableObject {
             return "개인정보 동의 안내"
         case .english:
             return "Privacy Consent"
-        case .japanese:
-            return "個人情報同意案内"
         }
     }
 
@@ -57,8 +53,6 @@ final class SettingsViewModel: ObservableObject {
             return "서비스 품질 향상을 위해 최소한의 이용 정보와 위치 기반 추천 정보가 사용됩니다."
         case .english:
             return "We only use minimal usage data and location-based context to improve recommendations."
-        case .japanese:
-            return "おすすめ品質向上のため、最小限の利用情報と位置ベース情報を利用します。"
         }
     }
 
@@ -68,8 +62,6 @@ final class SettingsViewModel: ObservableObject {
             return PrivacyNoticeContent.detailKo
         case .english:
             return PrivacyNoticeContent.detailEn
-        case .japanese:
-            return PrivacyNoticeContent.detailJa
         }
     }
 
@@ -79,8 +71,6 @@ final class SettingsViewModel: ObservableObject {
             return "자세히 보기"
         case .english:
             return "View Details"
-        case .japanese:
-            return "詳細を見る"
         }
     }
 
@@ -90,8 +80,6 @@ final class SettingsViewModel: ObservableObject {
             return "닫기"
         case .english:
             return "Close"
-        case .japanese:
-            return "閉じる"
         }
     }
 
@@ -101,8 +89,6 @@ final class SettingsViewModel: ObservableObject {
             return "위치기반 정보 제공 동의"
         case .english:
             return "Location-Based Data Consent"
-        case .japanese:
-            return "位置情報提供への同意"
         }
     }
 
@@ -112,8 +98,6 @@ final class SettingsViewModel: ObservableObject {
             return "언어"
         case .english:
             return "Language"
-        case .japanese:
-            return "言語"
         }
     }
 
@@ -123,8 +107,6 @@ final class SettingsViewModel: ObservableObject {
             return "글꼴 크기"
         case .english:
             return "Font Size"
-        case .japanese:
-            return "文字サイズ"
         }
     }
 }

--- a/src/frontend/ios/LALA/LALA/ViewModels/SettingsViewModel.swift
+++ b/src/frontend/ios/LALA/LALA/ViewModels/SettingsViewModel.swift
@@ -30,26 +30,101 @@ final class SettingsViewModel: ObservableObject {
     }
 
     func title(in language: AppLanguage) -> String {
-        language == .korean ? "설정" : "Settings"
+        switch language {
+        case .korean:
+            return "설정"
+        case .english:
+            return "Settings"
+        case .japanese:
+            return "設定"
+        }
     }
 
     func privacyTitle(in language: AppLanguage) -> String {
-        language == .korean ? "개인정보 동의 안내" : "Privacy Consent"
+        switch language {
+        case .korean:
+            return "개인정보 동의 안내"
+        case .english:
+            return "Privacy Consent"
+        case .japanese:
+            return "個人情報同意案内"
+        }
     }
 
     func privacyBody(in language: AppLanguage) -> String {
-        if language == .korean {
+        switch language {
+        case .korean:
             return "서비스 품질 향상을 위해 최소한의 이용 정보와 위치 기반 추천 정보가 사용됩니다."
+        case .english:
+            return "We only use minimal usage data and location-based context to improve recommendations."
+        case .japanese:
+            return "おすすめ品質向上のため、最小限の利用情報と位置ベース情報を利用します。"
         }
-
-        return "We only use minimal usage data and location-based context to improve recommendations."
     }
 
     func privacyDetail(in language: AppLanguage) -> String {
-        if language == .korean {
+        switch language {
+        case .korean:
             return PrivacyNoticeContent.detailKo
+        case .english:
+            return PrivacyNoticeContent.detailEn
+        case .japanese:
+            return PrivacyNoticeContent.detailJa
         }
+    }
 
-        return PrivacyNoticeContent.detailEn
+    func viewDetailsText(in language: AppLanguage) -> String {
+        switch language {
+        case .korean:
+            return "자세히 보기"
+        case .english:
+            return "View Details"
+        case .japanese:
+            return "詳細を見る"
+        }
+    }
+
+    func closeText(in language: AppLanguage) -> String {
+        switch language {
+        case .korean:
+            return "닫기"
+        case .english:
+            return "Close"
+        case .japanese:
+            return "閉じる"
+        }
+    }
+
+    func locationConsentTitle(in language: AppLanguage) -> String {
+        switch language {
+        case .korean:
+            return "위치기반 정보 제공 동의"
+        case .english:
+            return "Location-Based Data Consent"
+        case .japanese:
+            return "位置情報提供への同意"
+        }
+    }
+
+    func languageTitle(in language: AppLanguage) -> String {
+        switch language {
+        case .korean:
+            return "언어"
+        case .english:
+            return "Language"
+        case .japanese:
+            return "言語"
+        }
+    }
+
+    func fontSizeTitle(in language: AppLanguage) -> String {
+        switch language {
+        case .korean:
+            return "글꼴 크기"
+        case .english:
+            return "Font Size"
+        case .japanese:
+            return "文字サイズ"
+        }
     }
 }

--- a/src/frontend/ios/LALA/LALA/Views/MainMapView.swift
+++ b/src/frontend/ios/LALA/LALA/Views/MainMapView.swift
@@ -85,10 +85,6 @@ struct MainMapView: View {
                 statusBanner(status)
             }
 
-            if let selectedPlace = viewModel.selectedPlace {
-                recommendationPanel(for: selectedPlace)
-            }
-
             Spacer()
 
             subtitleView
@@ -146,41 +142,43 @@ struct MainMapView: View {
                         Button {
                             viewModel.handlePlaceTap(place, language: appViewModel.selectedLanguage)
                         } label: {
-                            VStack(alignment: .leading, spacing: 10) {
-                                PlaceCardImageView(imageURL: place.imageURL)
+                            HStack(alignment: .center, spacing: 10) {
+                                VStack(alignment: .leading, spacing: 5) {
+                                    Text(place.name(in: appViewModel.selectedLanguage))
+                                        .font(.system(size: 15 * appViewModel.fontScale, weight: .bold))
+                                        .foregroundStyle(Color(AppThemeColor.north.rawValue))
+                                        .lineLimit(2)
+                                        .minimumScaleFactor(0.85)
 
-                                Text(place.name(in: appViewModel.selectedLanguage))
-                                    .font(.system(size: 16 * appViewModel.fontScale, weight: .bold))
-                                    .foregroundStyle(Color(AppThemeColor.north.rawValue))
-                                    .lineLimit(2)
-                                    .minimumScaleFactor(0.85)
+                                    Text(place.category(in: appViewModel.selectedLanguage))
+                                        .font(.system(size: 12 * appViewModel.fontScale, weight: .semibold))
+                                        .foregroundStyle(Color(AppThemeColor.east.rawValue))
+                                        .lineLimit(1)
 
-                                Text(place.category(in: appViewModel.selectedLanguage))
-                                    .font(.system(size: 13 * appViewModel.fontScale, weight: .semibold))
-                                    .foregroundStyle(Color(AppThemeColor.east.rawValue))
+                                    HStack(spacing: 6) {
+                                        Text(place.district(in: appViewModel.selectedLanguage))
+                                            .font(.system(size: 11 * appViewModel.fontScale, weight: .medium))
+                                            .foregroundStyle(.secondary)
+                                            .lineLimit(1)
 
-                                HStack(spacing: 8) {
-                                    Text(place.district(in: appViewModel.selectedLanguage))
-                                        .font(.system(size: 12 * appViewModel.fontScale, weight: .medium))
-                                        .foregroundStyle(.secondary)
-
-                                    if let distance = place.distanceLabel(in: appViewModel.selectedLanguage) {
-                                        Text(distance)
-                                            .font(.system(size: 12 * appViewModel.fontScale, weight: .semibold))
-                                            .foregroundStyle(Color(AppThemeColor.north.rawValue).opacity(0.75))
+                                        if let distance = place.distanceLabel(in: appViewModel.selectedLanguage) {
+                                            Text(distance)
+                                                .font(.system(size: 11 * appViewModel.fontScale, weight: .semibold))
+                                                .foregroundStyle(Color(AppThemeColor.north.rawValue).opacity(0.7))
+                                                .lineLimit(1)
+                                        }
                                     }
                                 }
+                                .frame(maxWidth: .infinity, alignment: .leading)
 
-                                let address = place.address(in: appViewModel.selectedLanguage)
-                                if !address.isEmpty {
-                                    Text(address)
-                                        .font(.system(size: 11 * appViewModel.fontScale, weight: .regular))
-                                        .foregroundStyle(.secondary)
-                                        .lineLimit(2)
-                                }
+                                PlaceCardImageView(
+                                    imageURL: place.imageURL,
+                                    sideLength: 86
+                                )
                             }
-                            .frame(width: 240, alignment: .leading)
-                            .padding(12)
+                            .frame(width: 252, alignment: .leading)
+                            .padding(.horizontal, 10)
+                            .padding(.vertical, 8)
                             .background(
                                 RoundedRectangle(cornerRadius: 16, style: .continuous)
                                     .fill(Color.white.opacity(0.92))
@@ -236,28 +234,6 @@ struct MainMapView: View {
             Capsule(style: .continuous)
                 .fill(Color.white.opacity(0.94))
         )
-    }
-
-    private func recommendationPanel(for place: PlaceRecommendation) -> some View {
-        VStack(alignment: .leading, spacing: 6) {
-            Text(viewModel.recommendationTitle(for: appViewModel.selectedLanguage))
-                .font(.system(size: 12 * appViewModel.fontScale, weight: .bold))
-                .foregroundStyle(Color(AppThemeColor.east.rawValue))
-
-            Text(viewModel.recommendationReason(for: place, language: appViewModel.selectedLanguage))
-                .font(.system(size: 13 * appViewModel.fontScale, weight: .medium))
-                .foregroundStyle(Color(AppThemeColor.north.rawValue))
-                .lineLimit(3)
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(.horizontal, 14)
-        .padding(.vertical, 10)
-        .background(
-            RoundedRectangle(cornerRadius: 14, style: .continuous)
-                .fill(Color.white.opacity(0.94))
-        )
-        .padding(.horizontal, 16)
-        .transition(.opacity.combined(with: .move(edge: .top)))
     }
 
     private func statusBanner(_ text: String) -> some View {
@@ -528,6 +504,7 @@ private struct PlacePinView: View {
 
 private struct PlaceCardImageView: View {
     let imageURL: URL?
+    var sideLength: CGFloat = 108
 
     var body: some View {
         ZStack {
@@ -558,7 +535,7 @@ private struct PlaceCardImageView: View {
                 placeholder
             }
         }
-        .frame(height: 108)
+        .frame(width: sideLength, height: sideLength)
         .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
         .overlay(
             RoundedRectangle(cornerRadius: 12, style: .continuous)

--- a/src/frontend/ios/LALA/LALA/Views/MainMapView.swift
+++ b/src/frontend/ios/LALA/LALA/Views/MainMapView.swift
@@ -117,7 +117,7 @@ struct MainMapView: View {
                             .font(.system(size: 13 * appViewModel.fontScale, weight: .semibold))
                             .foregroundStyle(
                                 viewModel.selectedFilter == filter
-                                    ? Color.white
+                                    ? chipSelectedTextColor(for: filter)
                                     : Color(AppThemeColor.north.rawValue)
                             )
                             .padding(.horizontal, 14)
@@ -126,7 +126,7 @@ struct MainMapView: View {
                                 Capsule(style: .continuous)
                                     .fill(
                                         viewModel.selectedFilter == filter
-                                            ? Color(AppThemeColor.east.rawValue)
+                                            ? chipSelectedBackgroundColor(for: filter)
                                             : Color.white.opacity(0.93)
                                     )
                             )
@@ -401,6 +401,28 @@ struct MainMapView: View {
             return "현재 위치로 이동"
         case .english:
             return "Go to current location"
+        }
+    }
+
+    private func chipSelectedBackgroundColor(for filter: MapPlaceFilter) -> Color {
+        switch filter {
+        case .all:
+            return Color(AppThemeColor.north.rawValue)
+        case .attraction:
+            return Color(AppThemeColor.south.rawValue)
+        case .restaurant:
+            return Color(AppThemeColor.center.rawValue)
+        case .event:
+            return Color(AppThemeColor.east.rawValue)
+        }
+    }
+
+    private func chipSelectedTextColor(for filter: MapPlaceFilter) -> Color {
+        switch filter {
+        case .restaurant:
+            return Color(AppThemeColor.north.rawValue)
+        default:
+            return .white
         }
     }
 }

--- a/src/frontend/ios/LALA/LALA/Views/MainMapView.swift
+++ b/src/frontend/ios/LALA/LALA/Views/MainMapView.swift
@@ -25,6 +25,7 @@ struct MainMapView: View {
                     PlacePinView(
                         title: place.name(in: appViewModel.selectedLanguage),
                         categorySymbol: place.categoryKind.symbolName,
+                        categoryKind: place.categoryKind,
                         isSelected: viewModel.selectedPlaceID == place.id
                     )
                     .onTapGesture {
@@ -145,11 +146,14 @@ struct MainMapView: View {
                         Button {
                             viewModel.handlePlaceTap(place, language: appViewModel.selectedLanguage)
                         } label: {
-                            VStack(alignment: .leading, spacing: 6) {
+                            VStack(alignment: .leading, spacing: 10) {
+                                PlaceCardImageView(imageURL: place.imageURL)
+
                                 Text(place.name(in: appViewModel.selectedLanguage))
                                     .font(.system(size: 16 * appViewModel.fontScale, weight: .bold))
                                     .foregroundStyle(Color(AppThemeColor.north.rawValue))
-                                    .lineLimit(1)
+                                    .lineLimit(2)
+                                    .minimumScaleFactor(0.85)
 
                                 Text(place.category(in: appViewModel.selectedLanguage))
                                     .font(.system(size: 13 * appViewModel.fontScale, weight: .semibold))
@@ -172,11 +176,11 @@ struct MainMapView: View {
                                     Text(address)
                                         .font(.system(size: 11 * appViewModel.fontScale, weight: .regular))
                                         .foregroundStyle(.secondary)
-                                        .lineLimit(1)
+                                        .lineLimit(2)
                                 }
                             }
-                            .frame(width: 230, alignment: .leading)
-                            .padding(14)
+                            .frame(width: 240, alignment: .leading)
+                            .padding(12)
                             .background(
                                 RoundedRectangle(cornerRadius: 16, style: .continuous)
                                     .fill(Color.white.opacity(0.92))
@@ -447,6 +451,7 @@ private struct AnimatedObangBorder: View {
 private struct PlacePinView: View {
     let title: String
     let categorySymbol: String
+    let categoryKind: PlaceCategoryKind
     let isSelected: Bool
 
     var body: some View {
@@ -474,8 +479,8 @@ private struct PlacePinView: View {
                 Circle()
                     .fill(
                         isSelected
-                            ? Color(AppThemeColor.south.rawValue)
-                            : Color(AppThemeColor.north.rawValue).opacity(0.88)
+                            ? pinColor
+                            : pinColor.opacity(0.9)
                     )
                     .frame(width: isSelected ? 22 : 18, height: isSelected ? 22 : 18)
 
@@ -485,5 +490,73 @@ private struct PlacePinView: View {
             }
         }
         .frame(maxWidth: 150)
+    }
+
+    private var pinColor: Color {
+        switch categoryKind {
+        case .attraction:
+            return Color(AppThemeColor.south.rawValue)
+        case .restaurant:
+            return Color(AppThemeColor.center.rawValue)
+        case .event:
+            return Color(AppThemeColor.east.rawValue)
+        }
+    }
+}
+
+private struct PlaceCardImageView: View {
+    let imageURL: URL?
+
+    var body: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .fill(
+                    LinearGradient(
+                        colors: [
+                            Color(AppThemeColor.center.rawValue).opacity(0.65),
+                            Color(AppThemeColor.east.rawValue).opacity(0.45)
+                        ],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    )
+                )
+
+            if let imageURL {
+                AsyncImage(url: imageURL) { phase in
+                    switch phase {
+                    case let .success(image):
+                        image
+                            .resizable()
+                            .scaledToFill()
+                    default:
+                        placeholder
+                    }
+                }
+            } else {
+                placeholder
+            }
+        }
+        .frame(height: 108)
+        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .stroke(Color.white.opacity(0.3), lineWidth: 1)
+        )
+    }
+
+    private var placeholder: some View {
+        ZStack {
+            LinearGradient(
+                colors: [
+                    Color(AppThemeColor.west.rawValue).opacity(0.8),
+                    Color(AppThemeColor.center.rawValue).opacity(0.6)
+                ],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+            Image(systemName: "photo")
+                .font(.system(size: 20, weight: .semibold))
+                .foregroundStyle(Color(AppThemeColor.north.rawValue).opacity(0.6))
+        }
     }
 }

--- a/src/frontend/ios/LALA/LALA/Views/MainMapView.swift
+++ b/src/frontend/ios/LALA/LALA/Views/MainMapView.swift
@@ -361,8 +361,6 @@ struct MainMapView: View {
             return "주변 장소 로딩 중..."
         case .english:
             return "Loading nearby places..."
-        case .japanese:
-            return "周辺スポットを読み込み中..."
         }
     }
 
@@ -372,8 +370,6 @@ struct MainMapView: View {
             return "다시시도"
         case .english:
             return "Retry"
-        case .japanese:
-            return "再試行"
         }
     }
 
@@ -383,8 +379,6 @@ struct MainMapView: View {
             return "설정"
         case .english:
             return "Settings"
-        case .japanese:
-            return "設定"
         }
     }
 
@@ -394,8 +388,6 @@ struct MainMapView: View {
             return "음성 안내 토글"
         case .english:
             return "Toggle voice guidance"
-        case .japanese:
-            return "音声ガイド切替"
         }
     }
 
@@ -405,8 +397,6 @@ struct MainMapView: View {
             return "현재 위치로 이동"
         case .english:
             return "Go to current location"
-        case .japanese:
-            return "現在地へ移動"
         }
     }
 }

--- a/src/frontend/ios/LALA/LALA/Views/MainMapView.swift
+++ b/src/frontend/ios/LALA/LALA/Views/MainMapView.swift
@@ -12,7 +12,6 @@ struct MainMapView: View {
     @ObservedObject var appViewModel: AppViewModel
     @StateObject private var viewModel = MainMapViewModel()
     @State private var showSettings = false
-    @State private var userTrackingMode: MapUserTrackingMode = .none
 
     var body: some View {
         ZStack {
@@ -20,7 +19,6 @@ struct MainMapView: View {
                 coordinateRegion: boundedRegionBinding,
                 interactionModes: [.pan, .zoom],
                 showsUserLocation: true,
-                userTrackingMode: $userTrackingMode,
                 annotationItems: viewModel.places
             ) { place in
                 MapAnnotation(coordinate: place.coordinate) {
@@ -40,11 +38,11 @@ struct MainMapView: View {
             overlayContent
         }
         .onAppear {
-            viewModel.refreshSubtitle(for: appViewModel.selectedLanguage)
+            viewModel.updateLanguage(appViewModel.selectedLanguage)
             viewModel.configureLocationUpdates(consentEnabled: appViewModel.isLocationConsentEnabled)
         }
         .onChange(of: appViewModel.selectedLanguage) { _, newValue in
-            viewModel.refreshSubtitle(for: newValue)
+            viewModel.updateLanguage(newValue)
         }
         .onChange(of: appViewModel.isLocationConsentEnabled) { _, consent in
             viewModel.configureLocationUpdates(consentEnabled: consent)
@@ -65,9 +63,11 @@ struct MainMapView: View {
     }
 
     private var overlayContent: some View {
-        VStack(spacing: 12) {
+        VStack(spacing: 10) {
+            placeFilterChips
+
             placeCarousel
-                .padding(.top, 4)
+                .padding(.top, 2)
 
             HStack {
                 settingsButton
@@ -75,6 +75,14 @@ struct MainMapView: View {
                 weatherView
             }
             .padding(.horizontal, 16)
+
+            if viewModel.isLoadingPlaces {
+                loadingBadge
+            }
+
+            if let status = viewModel.statusMessage(for: appViewModel.selectedLanguage) {
+                statusBanner(status)
+            }
 
             Spacer()
 
@@ -91,6 +99,38 @@ struct MainMapView: View {
         }
         .safeAreaPadding(.top, 10)
         .safeAreaPadding(.bottom, 8)
+    }
+
+    private var placeFilterChips: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 8) {
+                ForEach(MapPlaceFilter.allCases) { filter in
+                    Button {
+                        viewModel.selectFilter(filter)
+                    } label: {
+                        Text(filter.title(in: appViewModel.selectedLanguage))
+                            .font(.system(size: 13 * appViewModel.fontScale, weight: .semibold))
+                            .foregroundStyle(
+                                viewModel.selectedFilter == filter
+                                    ? Color.white
+                                    : Color(AppThemeColor.north.rawValue)
+                            )
+                            .padding(.horizontal, 14)
+                            .padding(.vertical, 8)
+                            .background(
+                                Capsule(style: .continuous)
+                                    .fill(
+                                        viewModel.selectedFilter == filter
+                                            ? Color(AppThemeColor.east.rawValue)
+                                            : Color.white.opacity(0.93)
+                                    )
+                            )
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .padding(.horizontal, 14)
+        }
     }
 
     private var placeCarousel: some View {
@@ -111,11 +151,27 @@ struct MainMapView: View {
                                     .font(.system(size: 13 * appViewModel.fontScale, weight: .semibold))
                                     .foregroundStyle(Color(AppThemeColor.east.rawValue))
 
-                                Text(place.district(in: appViewModel.selectedLanguage))
-                                    .font(.system(size: 12 * appViewModel.fontScale, weight: .medium))
-                                    .foregroundStyle(.secondary)
+                                HStack(spacing: 8) {
+                                    Text(place.district(in: appViewModel.selectedLanguage))
+                                        .font(.system(size: 12 * appViewModel.fontScale, weight: .medium))
+                                        .foregroundStyle(.secondary)
+
+                                    if let distance = place.distanceLabel(in: appViewModel.selectedLanguage) {
+                                        Text(distance)
+                                            .font(.system(size: 12 * appViewModel.fontScale, weight: .semibold))
+                                            .foregroundStyle(Color(AppThemeColor.north.rawValue).opacity(0.75))
+                                    }
+                                }
+
+                                let address = place.address(in: appViewModel.selectedLanguage)
+                                if !address.isEmpty {
+                                    Text(address)
+                                        .font(.system(size: 11 * appViewModel.fontScale, weight: .regular))
+                                        .foregroundStyle(.secondary)
+                                        .lineLimit(1)
+                                }
                             }
-                            .frame(width: 210, alignment: .leading)
+                            .frame(width: 230, alignment: .leading)
                             .padding(14)
                             .background(
                                 RoundedRectangle(cornerRadius: 16, style: .continuous)
@@ -156,6 +212,49 @@ struct MainMapView: View {
                 .fill(Color.white.opacity(0.92))
         )
         .accessibilityLabel(viewModel.weatherA11yText(for: appViewModel.selectedLanguage))
+    }
+
+    private var loadingBadge: some View {
+        HStack(spacing: 10) {
+            ProgressView()
+                .tint(Color(AppThemeColor.east.rawValue))
+            Text(appViewModel.selectedLanguage == .korean ? "주변 장소 로딩 중..." : "Loading nearby places...")
+                .font(.system(size: 12 * appViewModel.fontScale, weight: .semibold))
+                .foregroundStyle(Color(AppThemeColor.north.rawValue))
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(
+            Capsule(style: .continuous)
+                .fill(Color.white.opacity(0.94))
+        )
+    }
+
+    private func statusBanner(_ text: String) -> some View {
+        HStack(spacing: 10) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(Color.orange)
+
+            Text(text)
+                .font(.system(size: 12 * appViewModel.fontScale, weight: .medium))
+                .foregroundStyle(Color(AppThemeColor.north.rawValue))
+                .multilineTextAlignment(.leading)
+
+            Spacer(minLength: 6)
+
+            Button(appViewModel.selectedLanguage == .korean ? "다시시도" : "Retry") {
+                viewModel.retryLoadingPlaces()
+            }
+            .font(.system(size: 12 * appViewModel.fontScale, weight: .bold))
+            .foregroundStyle(Color(AppThemeColor.east.rawValue))
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .fill(Color.white.opacity(0.95))
+        )
+        .padding(.horizontal, 16)
     }
 
     private var settingsButton: some View {
@@ -218,7 +317,6 @@ struct MainMapView: View {
 
     private var currentLocationButton: some View {
         Button {
-            userTrackingMode = .none
             viewModel.centerOnUserLocation(animated: true)
         } label: {
             Image(systemName: "location.fill")

--- a/src/frontend/ios/LALA/LALA/Views/MainMapView.swift
+++ b/src/frontend/ios/LALA/LALA/Views/MainMapView.swift
@@ -12,6 +12,7 @@ struct MainMapView: View {
     @ObservedObject var appViewModel: AppViewModel
     @StateObject private var viewModel = MainMapViewModel()
     @State private var showSettings = false
+    @State private var selectedDetailPlace: PlaceRecommendation?
 
     var body: some View {
         ZStack {
@@ -30,6 +31,7 @@ struct MainMapView: View {
                     )
                     .onTapGesture {
                         viewModel.handleMapPinTap(place, language: appViewModel.selectedLanguage)
+                        selectedDetailPlace = place
                     }
                 }
             }
@@ -51,6 +53,21 @@ struct MainMapView: View {
         .navigationBarBackButtonHidden(true)
         .navigationDestination(isPresented: $showSettings) {
             SettingsView(viewModel: SettingsViewModel(appViewModel: appViewModel))
+        }
+        .sheet(item: $selectedDetailPlace) { place in
+            PlaceDetailBottomSheet(
+                place: place,
+                language: appViewModel.selectedLanguage,
+                fontScale: appViewModel.fontScale,
+                recommendationText: viewModel.recommendationReason(for: place, language: appViewModel.selectedLanguage),
+                moreInfoButtonTitle: viewModel.moreInfoButtonTitle(for: appViewModel.selectedLanguage),
+                showMoreInfoButton: viewModel.canPlayMoreInfo(for: place.id),
+                onPlayMoreInfo: {
+                    viewModel.playMoreInfo(for: place, language: appViewModel.selectedLanguage)
+                }
+            )
+            .presentationDetents([.medium])
+            .presentationDragIndicator(.visible)
         }
     }
 
@@ -189,6 +206,13 @@ struct MainMapView: View {
                             }
                         }
                         .buttonStyle(.plain)
+                        .simultaneousGesture(
+                            LongPressGesture(minimumDuration: 0.45)
+                                .onEnded { _ in
+                                    viewModel.activatePlaceForDetail(place, language: appViewModel.selectedLanguage)
+                                    selectedDetailPlace = place
+                                }
+                        )
                         .id(place.id)
                     }
                 }
@@ -281,20 +305,40 @@ struct MainMapView: View {
     }
 
     private var subtitleView: some View {
-        Text(viewModel.subtitle)
-            .font(.system(size: 15 * appViewModel.fontScale, weight: .medium))
-            .foregroundStyle(Color(AppThemeColor.north.rawValue))
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.horizontal, 16)
-            .padding(.vertical, 14)
-            .background(
-                RoundedRectangle(cornerRadius: 16, style: .continuous)
-                    .fill(Color.white.opacity(0.92))
-            )
-            .overlay {
-                AnimatedObangBorder(cornerRadius: 16, isActive: viewModel.selectedPlaceID != nil)
+        VStack(alignment: .leading, spacing: 10) {
+            Text(viewModel.subtitle)
+                .font(.system(size: 15 * appViewModel.fontScale, weight: .medium))
+                .foregroundStyle(Color(AppThemeColor.north.rawValue))
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+            if let selectedPlace = viewModel.selectedPlace,
+               viewModel.canPlayMoreInfo(for: selectedPlace.id) {
+                Button {
+                    viewModel.playMoreInfo(for: selectedPlace, language: appViewModel.selectedLanguage)
+                } label: {
+                    Text(viewModel.moreInfoButtonTitle(for: appViewModel.selectedLanguage))
+                        .font(.system(size: 13 * appViewModel.fontScale, weight: .bold))
+                        .foregroundStyle(.white)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 8)
+                        .background(
+                            Capsule(style: .continuous)
+                                .fill(Color(AppThemeColor.east.rawValue))
+                        )
+                }
+                .buttonStyle(.plain)
             }
-            .padding(.horizontal, 14)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 14)
+        .background(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(Color.white.opacity(0.92))
+        )
+        .overlay {
+            AnimatedObangBorder(cornerRadius: 16, isActive: viewModel.selectedPlaceID != nil)
+        }
+        .padding(.horizontal, 14)
     }
 
     private var muteToggleButton: some View {
@@ -441,6 +485,138 @@ struct MainMapView: View {
             return Color(AppThemeColor.south.rawValue).opacity(0.95)
         case .restaurant:
             // Yellow needs a darker tone on white cards for readability.
+            return Color(red: 0.55, green: 0.45, blue: 0.12)
+        case .event:
+            return Color(AppThemeColor.east.rawValue).opacity(0.95)
+        }
+    }
+}
+
+private struct PlaceDetailBottomSheet: View {
+    let place: PlaceRecommendation
+    let language: AppLanguage
+    let fontScale: CGFloat
+    let recommendationText: String
+    let moreInfoButtonTitle: String
+    let showMoreInfoButton: Bool
+    let onPlayMoreInfo: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            heroImage
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text(place.name(in: language))
+                    .font(.system(size: 18 * fontScale, weight: .bold))
+                    .foregroundStyle(Color(AppThemeColor.north.rawValue))
+                    .lineLimit(2)
+
+                Text(place.category(in: language))
+                    .font(.system(size: 13 * fontScale, weight: .semibold))
+                    .foregroundStyle(categoryColor(for: place.categoryKind))
+
+                HStack(spacing: 6) {
+                    Text(place.district(in: language))
+                        .font(.system(size: 12 * fontScale, weight: .medium))
+                        .foregroundStyle(.secondary)
+
+                    if let distance = place.distanceLabel(in: language) {
+                        Text(distance)
+                            .font(.system(size: 12 * fontScale, weight: .semibold))
+                            .foregroundStyle(Color(AppThemeColor.north.rawValue).opacity(0.75))
+                    }
+                }
+
+                Text(place.address(in: language))
+                    .font(.system(size: 12 * fontScale, weight: .regular))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+            }
+
+            Text(recommendationText)
+                .font(.system(size: 13 * fontScale, weight: .medium))
+                .foregroundStyle(Color(AppThemeColor.north.rawValue))
+                .lineLimit(4)
+
+            if showMoreInfoButton {
+                Button(action: onPlayMoreInfo) {
+                    Text(moreInfoButtonTitle)
+                        .font(.system(size: 14 * fontScale, weight: .bold))
+                        .foregroundStyle(.white)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 12)
+                        .background(
+                            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                                .fill(Color(AppThemeColor.east.rawValue))
+                        )
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(.horizontal, 18)
+        .padding(.top, 16)
+        .padding(.bottom, 22)
+    }
+
+    private var heroImage: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .fill(
+                    LinearGradient(
+                        colors: [
+                            Color(AppThemeColor.center.rawValue).opacity(0.6),
+                            Color(AppThemeColor.east.rawValue).opacity(0.45)
+                        ],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    )
+                )
+
+            if let imageURL = place.imageURL {
+                AsyncImage(url: imageURL) { phase in
+                    switch phase {
+                    case let .success(image):
+                        image
+                            .resizable()
+                            .scaledToFill()
+                    default:
+                        heroPlaceholder
+                    }
+                }
+            } else {
+                heroPlaceholder
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .frame(height: 170)
+        .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .stroke(Color.white.opacity(0.3), lineWidth: 1)
+        )
+    }
+
+    private var heroPlaceholder: some View {
+        ZStack {
+            LinearGradient(
+                colors: [
+                    Color(AppThemeColor.west.rawValue).opacity(0.85),
+                    Color(AppThemeColor.center.rawValue).opacity(0.65)
+                ],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+            Image(systemName: "photo")
+                .font(.system(size: 28, weight: .semibold))
+                .foregroundStyle(Color(AppThemeColor.north.rawValue).opacity(0.6))
+        }
+    }
+
+    private func categoryColor(for kind: PlaceCategoryKind) -> Color {
+        switch kind {
+        case .attraction:
+            return Color(AppThemeColor.south.rawValue).opacity(0.95)
+        case .restaurant:
             return Color(red: 0.55, green: 0.45, blue: 0.12)
         case .event:
             return Color(AppThemeColor.east.rawValue).opacity(0.95)

--- a/src/frontend/ios/LALA/LALA/Views/MainMapView.swift
+++ b/src/frontend/ios/LALA/LALA/Views/MainMapView.swift
@@ -84,6 +84,10 @@ struct MainMapView: View {
                 statusBanner(status)
             }
 
+            if let selectedPlace = viewModel.selectedPlace {
+                recommendationPanel(for: selectedPlace)
+            }
+
             Spacer()
 
             subtitleView
@@ -218,7 +222,7 @@ struct MainMapView: View {
         HStack(spacing: 10) {
             ProgressView()
                 .tint(Color(AppThemeColor.east.rawValue))
-            Text(appViewModel.selectedLanguage == .korean ? "주변 장소 로딩 중..." : "Loading nearby places...")
+            Text(loadingText)
                 .font(.system(size: 12 * appViewModel.fontScale, weight: .semibold))
                 .foregroundStyle(Color(AppThemeColor.north.rawValue))
         }
@@ -228,6 +232,28 @@ struct MainMapView: View {
             Capsule(style: .continuous)
                 .fill(Color.white.opacity(0.94))
         )
+    }
+
+    private func recommendationPanel(for place: PlaceRecommendation) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(viewModel.recommendationTitle(for: appViewModel.selectedLanguage))
+                .font(.system(size: 12 * appViewModel.fontScale, weight: .bold))
+                .foregroundStyle(Color(AppThemeColor.east.rawValue))
+
+            Text(viewModel.recommendationReason(for: place, language: appViewModel.selectedLanguage))
+                .font(.system(size: 13 * appViewModel.fontScale, weight: .medium))
+                .foregroundStyle(Color(AppThemeColor.north.rawValue))
+                .lineLimit(3)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
+        .background(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .fill(Color.white.opacity(0.94))
+        )
+        .padding(.horizontal, 16)
+        .transition(.opacity.combined(with: .move(edge: .top)))
     }
 
     private func statusBanner(_ text: String) -> some View {
@@ -242,7 +268,7 @@ struct MainMapView: View {
 
             Spacer(minLength: 6)
 
-            Button(appViewModel.selectedLanguage == .korean ? "다시시도" : "Retry") {
+            Button(retryText) {
                 viewModel.retryLoadingPlaces()
             }
             .font(.system(size: 12 * appViewModel.fontScale, weight: .bold))
@@ -270,7 +296,7 @@ struct MainMapView: View {
                         .fill(Color.white.opacity(0.93))
                 )
         }
-        .accessibilityLabel(appViewModel.selectedLanguage == .korean ? "설정" : "Settings")
+        .accessibilityLabel(settingsText)
     }
 
     private var subtitleView: some View {
@@ -309,9 +335,7 @@ struct MainMapView: View {
             }
         }
         .accessibilityLabel(
-            appViewModel.selectedLanguage == .korean
-                ? "음성 안내 토글"
-                : "Toggle voice guidance"
+            toggleVoiceText
         )
     }
 
@@ -327,8 +351,63 @@ struct MainMapView: View {
                     Circle().fill(Color(AppThemeColor.east.rawValue))
                 )
         }
-        .accessibilityLabel(appViewModel.selectedLanguage == .korean ? "현재 위치로 이동" : "Go to current location")
+        .accessibilityLabel(currentLocationText)
         .shadow(color: .black.opacity(0.15), radius: 6, y: 3)
+    }
+
+    private var loadingText: String {
+        switch appViewModel.selectedLanguage {
+        case .korean:
+            return "주변 장소 로딩 중..."
+        case .english:
+            return "Loading nearby places..."
+        case .japanese:
+            return "周辺スポットを読み込み中..."
+        }
+    }
+
+    private var retryText: String {
+        switch appViewModel.selectedLanguage {
+        case .korean:
+            return "다시시도"
+        case .english:
+            return "Retry"
+        case .japanese:
+            return "再試行"
+        }
+    }
+
+    private var settingsText: String {
+        switch appViewModel.selectedLanguage {
+        case .korean:
+            return "설정"
+        case .english:
+            return "Settings"
+        case .japanese:
+            return "設定"
+        }
+    }
+
+    private var toggleVoiceText: String {
+        switch appViewModel.selectedLanguage {
+        case .korean:
+            return "음성 안내 토글"
+        case .english:
+            return "Toggle voice guidance"
+        case .japanese:
+            return "音声ガイド切替"
+        }
+    }
+
+    private var currentLocationText: String {
+        switch appViewModel.selectedLanguage {
+        case .korean:
+            return "현재 위치로 이동"
+        case .english:
+            return "Go to current location"
+        case .japanese:
+            return "現在地へ移動"
+        }
     }
 }
 

--- a/src/frontend/ios/LALA/LALA/Views/MainMapView.swift
+++ b/src/frontend/ios/LALA/LALA/Views/MainMapView.swift
@@ -89,8 +89,9 @@ struct MainMapView: View {
 
             subtitleView
             ZStack {
-                voiceToggleButton
+                autoDocentModeButton
                 HStack {
+                    muteToggleButton
                     Spacer()
                     currentLocationButton
                 }
@@ -152,7 +153,7 @@ struct MainMapView: View {
 
                                     Text(place.category(in: appViewModel.selectedLanguage))
                                         .font(.system(size: 12 * appViewModel.fontScale, weight: .semibold))
-                                        .foregroundStyle(Color(AppThemeColor.east.rawValue))
+                                        .foregroundStyle(categoryTextColor(for: place.categoryKind))
                                         .lineLimit(1)
 
                                     HStack(spacing: 6) {
@@ -296,27 +297,50 @@ struct MainMapView: View {
             .padding(.horizontal, 14)
     }
 
-    private var voiceToggleButton: some View {
+    private var muteToggleButton: some View {
         Button {
             viewModel.toggleVoiceGuidance(for: appViewModel.selectedLanguage)
+        } label: {
+            Image(systemName: viewModel.isVoiceGuidanceEnabled ? "speaker.wave.3.fill" : "speaker.slash.fill")
+                .font(.system(size: 18, weight: .bold))
+                .foregroundStyle(.white)
+                .frame(width: 46, height: 46)
+                .background(
+                    Circle()
+                        .fill(
+                            viewModel.isVoiceGuidanceEnabled
+                                ? Color(AppThemeColor.east.rawValue)
+                                : Color(AppThemeColor.north.rawValue).opacity(0.8)
+                        )
+                )
+        }
+        .accessibilityLabel(muteVoiceText)
+        .shadow(color: .black.opacity(0.15), radius: 6, y: 3)
+    }
+
+    private var autoDocentModeButton: some View {
+        Button {
+            viewModel.toggleAutoDocentMode(for: appViewModel.selectedLanguage)
         } label: {
             ZStack {
                 Circle()
                     .fill(
-                        viewModel.isVoiceGuidanceEnabled
+                        viewModel.isAutoDocentEnabled
                             ? Color(AppThemeColor.east.rawValue)
                             : Color(AppThemeColor.north.rawValue).opacity(0.8)
                     )
                     .frame(width: 74, height: 74)
 
-                Image(systemName: viewModel.isVoiceGuidanceEnabled ? "speaker.wave.3.fill" : "speaker.slash.fill")
-                    .font(.system(size: 24, weight: .bold))
-                    .foregroundStyle(.white)
+                VStack(spacing: 2) {
+                    Image(systemName: "sparkles")
+                        .font(.system(size: 17, weight: .bold))
+                    Text(viewModel.isAutoDocentEnabled ? "ON" : "OFF")
+                        .font(.system(size: 10, weight: .bold))
+                }
+                .foregroundStyle(.white)
             }
         }
-        .accessibilityLabel(
-            toggleVoiceText
-        )
+        .accessibilityLabel(autoDocentText)
     }
 
     private var currentLocationButton: some View {
@@ -362,12 +386,12 @@ struct MainMapView: View {
         }
     }
 
-    private var toggleVoiceText: String {
+    private var muteVoiceText: String {
         switch appViewModel.selectedLanguage {
         case .korean:
-            return "음성 안내 토글"
+            return "음성 안내 음소거 토글"
         case .english:
-            return "Toggle voice guidance"
+            return "Toggle voice mute"
         }
     }
 
@@ -377,6 +401,15 @@ struct MainMapView: View {
             return "현재 위치로 이동"
         case .english:
             return "Go to current location"
+        }
+    }
+
+    private var autoDocentText: String {
+        switch appViewModel.selectedLanguage {
+        case .korean:
+            return "자동 도슨트 모드 토글"
+        case .english:
+            return "Toggle auto docent mode"
         }
     }
 
@@ -399,6 +432,18 @@ struct MainMapView: View {
             return Color(AppThemeColor.north.rawValue)
         default:
             return .white
+        }
+    }
+
+    private func categoryTextColor(for kind: PlaceCategoryKind) -> Color {
+        switch kind {
+        case .attraction:
+            return Color(AppThemeColor.south.rawValue).opacity(0.95)
+        case .restaurant:
+            // Yellow needs a darker tone on white cards for readability.
+            return Color(red: 0.55, green: 0.45, blue: 0.12)
+        case .event:
+            return Color(AppThemeColor.east.rawValue).opacity(0.95)
         }
     }
 }

--- a/src/frontend/ios/LALA/LALA/Views/SettingsView.swift
+++ b/src/frontend/ios/LALA/LALA/Views/SettingsView.swift
@@ -33,7 +33,7 @@ struct SettingsView: View {
             Text(viewModel.privacyBody(in: viewModel.selectedLanguage))
                 .font(.system(size: 14 * viewModel.fontScale, weight: .regular))
                 .foregroundStyle(.secondary)
-            Button(viewModel.selectedLanguage == .korean ? "자세히 보기" : "View Details") {
+            Button(viewModel.viewDetailsText(in: viewModel.selectedLanguage)) {
                 showPrivacyDetail = true
             }
             .font(.system(size: 13 * viewModel.fontScale, weight: .semibold))
@@ -54,7 +54,7 @@ struct SettingsView: View {
                 .navigationBarTitleDisplayMode(.inline)
                 .toolbar {
                     ToolbarItem(placement: .topBarTrailing) {
-                        Button(viewModel.selectedLanguage == .korean ? "닫기" : "Close") {
+                        Button(viewModel.closeText(in: viewModel.selectedLanguage)) {
                             showPrivacyDetail = false
                         }
                     }
@@ -67,9 +67,7 @@ struct SettingsView: View {
     private var locationConsentCard: some View {
         VStack(alignment: .leading, spacing: 8) {
             Toggle(
-                viewModel.selectedLanguage == .korean
-                    ? "위치기반 정보 제공 동의"
-                    : "Location-Based Data Consent",
+                viewModel.locationConsentTitle(in: viewModel.selectedLanguage),
                 isOn: Binding(
                     get: { viewModel.isLocationConsentEnabled },
                     set: { value in
@@ -86,7 +84,7 @@ struct SettingsView: View {
 
     private var languageCard: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Text(viewModel.selectedLanguage == .korean ? "언어" : "Language")
+            Text(viewModel.languageTitle(in: viewModel.selectedLanguage))
                 .font(.system(size: 16 * viewModel.fontScale, weight: .semibold))
             Picker(
                 "",
@@ -110,7 +108,7 @@ struct SettingsView: View {
 
     private var fontCard: some View {
         VStack(alignment: .leading, spacing: 10) {
-            Text(viewModel.selectedLanguage == .korean ? "글꼴 크기" : "Font Size")
+            Text(viewModel.fontSizeTitle(in: viewModel.selectedLanguage))
                 .font(.system(size: 16 * viewModel.fontScale, weight: .semibold))
 
             Slider(


### PR DESCRIPTION
## Summary
- 상단 카드뷰에 이미지 추가,사용자 위치 기준 거리 계산 고정, 자동 도슨트 100m 트리거, 하단 제어 버튼 구조 개선을 반영했습니다.

## Changes
- 카드뷰에 이미지를 추가했습니다.
- 필터칩 추가후, 오방색에 맞게 컬러를 통일했습니다.
- 지도 pan/zoom 시 재조회 제거, 사용자 위치(anchor) 기준으로 장소/날씨 조회하도록 수정했습니다.
- 중앙 버튼을 자동 도슨트 ON/OFF로 변경하고, 기존 음성 버튼은 좌측 소형 음소거 버튼으로 분리했습니다.
- 자동 도슨트 반경 상수(`autoDocentTriggerRadiusMeters = 100`)를 추가하고 100m 외 무반응, 진입 시 자동 안내되도록 구현했습니다.
- `Publishing changes from within view updates` 경고 완화를 위해 지도 region 업데이트를 MainActor Task로 지연 반영했습니다.
- 마커를 누르거나 상단의 카드를 롱 프레스 할 경우 바텀뷰 표시
- 정보 더 듣기 도슨트 모드 추가 

## Test
- `cd src/frontend/ios/LALA && swift test`
- `cd src/frontend/ios/LALA && xcodebuild -project LALA.xcodeproj -scheme LALA -sdk iphonesimulator -configuration Debug build`

## Related
- Closes #60
<img width="547" height="1041" alt="image" src="https://github.com/user-attachments/assets/fcd16ef7-265a-41df-8956-7c96dc35c64f" /> 
<img width="503" height="997" alt="image" src="https://github.com/user-attachments/assets/50e74a35-cd69-4239-b0a0-5059f0715990" />
<img width="547" height="1041" alt="image" src="https://github.com/user-attachments/assets/a74cab51-c894-4aa7-928c-09ee1fcb8cae" />





