### PR TITLE
feat(db): add English name and address columns to 3 static tables

### DIFF
--- a/scripts/ingest/_validate_hybrid_sql.py
+++ b/scripts/ingest/_validate_hybrid_sql.py
@@ -1,0 +1,34 @@
+"""hybrid_place_matching.sql 문법 검증 스크립트 (일회성)."""
+import psycopg2
+
+sql = open("sql/analytics/hybrid_place_matching.sql", encoding="utf-8").read()
+
+vec = "[" + ",".join(["0.01"] * 1536) + "]"
+test_sql = (
+    sql
+    .replace(":city",         "'수원'")
+    .replace(":user_lng",     "126.9990")
+    .replace(":user_lat",     "37.2665")
+    .replace(":radius_m",     "5000")
+    .replace(":query_vector", f"'{vec}'")
+    .replace(":top_k",        "3")
+)
+
+# WITH 절부터 잘라냄 (ALTER/UPDATE 제외)
+main_sql = test_sql[test_sql.index("WITH"):]
+
+conn = psycopg2.connect(
+    "host=lala-db.postgres.database.azure.com port=5432 "
+    "dbname=postgres user=admin_user password=Aremarem2 sslmode=require"
+)
+cur = conn.cursor()
+try:
+    cur.execute("EXPLAIN " + main_sql)
+    rows = cur.fetchall()
+    print(f"EXPLAIN 성공 — 플랜 라인 수: {len(rows)}")
+    for r in rows[:8]:
+        print(" ", r[0])
+except Exception as e:
+    print("오류:", e)
+finally:
+    conn.close()

--- a/scripts/ingest/enrich_addresses_en.py
+++ b/scripts/ingest/enrich_addresses_en.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python
+"""도로명주소 영문 변환 일괄 보강 (주소기반산업지원서비스 영문주소 API).
+
+대상 테이블:
+  1. locallink.tourist_spot_info   road_addr         → road_addr_en         (약 200건)
+  2. locallink.gg_restaurant_info  refine_roadnm_addr → refine_roadnm_addr_en (약 27,604건)
+
+동작 방식:
+  - 미처리 고유 주소를 DB에서 한 번에 로드
+  - ThreadPoolExecutor로 병렬 API 호출 (기본 5 workers)
+  - 동일 원문 주소는 캐시로 재사용 (API 중복 호출 방지)
+  - 1,000건 단위 배치 UPDATE
+
+Usage:
+    python scripts/ingest/enrich_addresses_en.py \\
+        --dsn "host=... dbname=... user=... password=... sslmode=require" \\
+        [--table tourist|restaurant|all]  (기본 all) \\
+        [--workers 5] \\
+        [--commit-size 1000] \\
+        [--dry-run]
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[2]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from src.api.juso_client import translate_address  # noqa: E402
+
+try:
+    import psycopg
+    def db_connect(dsn: str):
+        return psycopg.connect(dsn)
+except ModuleNotFoundError:
+    import psycopg2 as psycopg
+    def db_connect(dsn: str):
+        return psycopg.connect(dsn)
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    datefmt="%H:%M:%S",
+)
+logger = logging.getLogger(__name__)
+
+# ── 테이블 설정 ───────────────────────────────────────────────────────────────
+TARGETS = {
+    "tourist": {
+        "table":   "locallink.tourist_spot_info",
+        "src_col": "road_addr",
+        "tgt_col": "road_addr_en",
+    },
+    "restaurant": {
+        "table":   "locallink.gg_restaurant_info",
+        "src_col": "refine_roadnm_addr",
+        "tgt_col": "refine_roadnm_addr_en",
+    },
+}
+
+
+def ensure_column(cursor, table: str, col: str) -> None:
+    cursor.execute(f"ALTER TABLE {table} ADD COLUMN IF NOT EXISTS {col} TEXT;")
+    logger.info("컬럼 확인: %s.%s", table, col)
+
+
+def fetch_pending(cursor, table: str, src_col: str, tgt_col: str) -> list[str]:
+    """미처리 고유 주소 목록 반환 (NaN·빈값 제외)."""
+    cursor.execute(f"""
+        SELECT DISTINCT {src_col}
+        FROM   {table}
+        WHERE  {src_col} IS NOT NULL
+          AND  {src_col} != 'NaN'
+          AND  LENGTH(TRIM({src_col})) > 5
+          AND  ({tgt_col} IS NULL OR {tgt_col} = '')
+        ORDER  BY {src_col};
+    """)
+    return [row[0] for row in cursor.fetchall()]
+
+
+def translate_all(addresses: list[str], workers: int) -> dict[str, str | None]:
+    """병렬 API 호출로 {원문주소: 영문주소} 캐시 dict 반환."""
+    cache: dict[str, str | None] = {}
+    total = len(addresses)
+    done = 0
+
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        futures = {pool.submit(translate_address, addr): addr for addr in addresses}
+        for future in as_completed(futures):
+            addr = futures[future]
+            try:
+                cache[addr] = future.result()
+            except Exception as exc:
+                logger.debug("번역 실패 (%s): %s", addr, exc)
+                cache[addr] = None
+            done += 1
+            if done % 500 == 0 or done == total:
+                logger.info("API 호출 진행: %d / %d (%.0f%%)", done, total, done / total * 100)
+
+    return cache
+
+
+def batch_update(conn, table: str, src_col: str, tgt_col: str,
+                 cache: dict[str, str | None], commit_size: int) -> int:
+    """캐시에서 영문주소가 있는 것만 배치 UPDATE, 갱신 행수 반환."""
+    SQL = (
+        f"UPDATE {table} SET {tgt_col} = %s "
+        f"WHERE {src_col} = %s "
+        f"AND ({tgt_col} IS NULL OR {tgt_col} = '');"
+    )
+    params = [(en, ko) for ko, en in cache.items() if en]
+    total_updated = 0
+
+    for i in range(0, len(params), commit_size):
+        chunk = params[i: i + commit_size]
+        with conn.cursor() as cur:
+            cur.executemany(SQL, chunk)
+            total_updated += cur.rowcount
+        conn.commit()
+
+    return total_updated
+
+
+def run_target(conn, cfg: dict, workers: int, commit_size: int, dry_run: bool) -> None:
+    table, src_col, tgt_col = cfg["table"], cfg["src_col"], cfg["tgt_col"]
+
+    with conn.cursor() as cur:
+        ensure_column(cur, table, tgt_col)
+    conn.commit()
+
+    with conn.cursor() as cur:
+        addresses = fetch_pending(cur, table, src_col, tgt_col)
+
+    if not addresses:
+        logger.info("[%s] 처리할 주소 없음 — 건너뜀", table)
+        return
+
+    total = len(addresses)
+    logger.info("[%s] 총 %d 건 영문주소 변환 시작 (workers=%d)...", table, total, workers)
+
+    t0 = time.time()
+    cache = translate_all(addresses, workers)
+
+    hit  = sum(1 for v in cache.values() if v)
+    miss = total - hit
+    logger.info("[%s] 번역 완료: 성공 %d건 / 실패(None) %d건 (%.1f초)",
+                table, hit, miss, time.time() - t0)
+
+    if dry_run:
+        shown = [(ko, en) for ko, en in cache.items() if en][:10]
+        for ko, en in shown:
+            logger.info("[DRY-RUN] %-60s  ->  %s", ko, en)
+        if miss:
+            failed = [(ko, en) for ko, en in cache.items() if not en][:3]
+            for ko, _ in failed:
+                logger.info("[DRY-RUN] 번역실패: %s", ko)
+        return
+
+    updated = batch_update(conn, table, src_col, tgt_col, cache, commit_size)
+    logger.info("[%s] 완료 — 갱신: %d행 / 소요: %.1f초", table, updated, time.time() - t0)
+
+
+def run(dsn: str, tables: list[str], workers: int, commit_size: int, dry_run: bool) -> None:
+    conn = db_connect(dsn)
+    conn.autocommit = False
+    try:
+        for key in tables:
+            run_target(conn, TARGETS[key], workers, commit_size, dry_run)
+    except Exception:
+        conn.rollback()
+        logger.exception("오류 발생 — 롤백 완료.")
+        raise
+    finally:
+        conn.close()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="도로명주소 한국어 → 영문 보강 (주소기반산업지원서비스 API)"
+    )
+    parser.add_argument("--dsn", required=True, help="PostgreSQL DSN")
+    parser.add_argument(
+        "--table", choices=["tourist", "restaurant", "all"], default="all",
+        help="처리할 테이블 (기본 all)",
+    )
+    parser.add_argument("--workers", type=int, default=5, help="병렬 API 호출 수 (기본 5)")
+    parser.add_argument("--commit-size", type=int, default=1000, help="DB 커밋 단위 (기본 1000)")
+    parser.add_argument("--dry-run", action="store_true", help="DB에 쓰지 않고 10건만 출력")
+    args = parser.parse_args()
+
+    tables = ["tourist", "restaurant"] if args.table == "all" else [args.table]
+    run(args.dsn, tables, args.workers, args.commit_size, args.dry_run)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ingest/enrich_attraction_names_en.py
+++ b/scripts/ingest/enrich_attraction_names_en.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python
+"""K-Term API로 locallink.tourist_spot_info.tourist_nm 영문명 보강.
+
+Usage:
+    python scripts/ingest/enrich_attraction_names_en.py \\
+        --dsn "host=... dbname=... user=... password=... sslmode=require" \\
+        [--batch-size 50] \\
+        [--dry-run]
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+import time
+from pathlib import Path
+
+# ── 프로젝트 루트 sys.path 등록 ───────────────────────────────────────────────
+_ROOT = Path(__file__).resolve().parents[2]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from src.api.kterm_client import translate  # noqa: E402
+
+try:
+    import psycopg
+    def db_connect(dsn: str):
+        return psycopg.connect(dsn)
+except ModuleNotFoundError:
+    import psycopg2 as psycopg
+    def db_connect(dsn: str):
+        return psycopg.connect(dsn)
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    datefmt="%H:%M:%S",
+)
+logger = logging.getLogger(__name__)
+
+TABLE = "locallink.tourist_spot_info"
+SRC_COL = "tourist_nm"
+TGT_COL = "tourist_nm_en"
+
+
+def ensure_column(cursor) -> None:
+    """영문명 컬럼이 없으면 추가."""
+    cursor.execute(
+        f"""
+        ALTER TABLE {TABLE}
+        ADD COLUMN IF NOT EXISTS {TGT_COL} TEXT;
+        """
+    )
+    logger.info("컬럼 확인 완료: %s.%s", TABLE, TGT_COL)
+
+
+def fetch_pending(cursor, batch_size: int) -> list[str]:
+    """아직 영문명이 없는 고유 명소명 조회."""
+    cursor.execute(
+        f"""
+        SELECT DISTINCT {SRC_COL}
+        FROM   {TABLE}
+        WHERE  {SRC_COL} IS NOT NULL
+          AND  ({TGT_COL} IS NULL OR {TGT_COL} = '')
+        ORDER  BY {SRC_COL}
+        LIMIT  %s;
+        """,
+        (batch_size,),
+    )
+    return [row[0] for row in cursor.fetchall()]
+
+
+def update_name(cursor, name: str, name_en: str) -> int:
+    """해당 이름을 가진 모든 행 업데이트. 갱신 행 수 반환."""
+    cursor.execute(
+        f"""
+        UPDATE {TABLE}
+        SET    {TGT_COL} = %s
+        WHERE  {SRC_COL} = %s
+          AND  ({TGT_COL} IS NULL OR {TGT_COL} = '');
+        """,
+        (name_en, name),
+    )
+    return cursor.rowcount
+
+
+def run(dsn: str, batch_size: int, dry_run: bool) -> None:
+    conn = db_connect(dsn)
+    conn.autocommit = False
+
+    try:
+        with conn.cursor() as cur:
+            ensure_column(cur)
+            conn.commit()
+
+            names = fetch_pending(cur, batch_size)
+
+        if not names:
+            logger.info("보강할 명소명 없음 — 종료.")
+            return
+
+        logger.info("대상 명소 %d 건 처리 시작.", len(names))
+
+        total_updated = 0
+        total_skipped = 0
+
+        for i, name in enumerate(names, 1):
+            from src.api import kterm_client
+            if kterm_client._DAILY_LIMIT_EXCEEDED:
+                logger.warning("일일 한도 초과 — 나머지 %d 건 중단.", len(names) - i + 1)
+                break
+
+            name_en = translate(name)
+
+            if name_en:
+                if dry_run:
+                    logger.info("[DRY-RUN] %s → %s", name, name_en)
+                else:
+                    with conn.cursor() as cur:
+                        updated = update_name(cur, name, name_en)
+                    conn.commit()
+                    total_updated += updated
+                    logger.info("[%d/%d] ✔ %s → %s (%d행 갱신)", i, len(names), name, name_en, updated)
+            else:
+                total_skipped += 1
+                logger.info("[%d/%d] — %s (번역 결과 없음)", i, len(names), name)
+
+        logger.info(
+            "완료 — 갱신: %d행 / 건너뜀: %d건",
+            total_updated,
+            total_skipped,
+        )
+
+    except Exception:
+        conn.rollback()
+        logger.exception("오류 발생 — 롤백 완료.")
+        raise
+    finally:
+        conn.close()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="명소 한국어명 → 영문명 보강 (K-Term API)")
+    parser.add_argument("--dsn", required=True, help="PostgreSQL DSN")
+    parser.add_argument("--batch-size", type=int, default=100, help="처리 건수 (기본 100)")
+    parser.add_argument("--dry-run", action="store_true", help="DB에 쓰지 않고 결과만 출력")
+    args = parser.parse_args()
+
+    run(args.dsn, args.batch_size, args.dry_run)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ingest/enrich_event_names_en.py
+++ b/scripts/ingest/enrich_event_names_en.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python
+"""locallink.gyeonggi_events.title 영문명 보강 (Azure OpenAI 번역).
+
+Azure OpenAI Chat Completion API를 사용해 행사 제목을 자연스러운 영어로 번역.
+  - 30건씩 배치 요청 → 996건 약 34회 API 호출
+  - [기관명], (날짜), <부제> 등 구조적 요소 보존
+  - Key Vault에서 엔드포인트/키/배포명 자동 조회
+
+Usage:
+    python scripts/ingest/enrich_event_names_en.py \\
+        --dsn "host=... dbname=... user=... password=... sslmode=require" \\
+        [--batch-size 30] \\
+        [--commit-size 500] \\
+        [--dry-run]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+import time
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[2]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from config.vault_manager import get_vault_manager  # noqa: E402
+
+try:
+    import psycopg
+    def db_connect(dsn: str):
+        return psycopg.connect(dsn)
+except ModuleNotFoundError:
+    import psycopg2 as psycopg
+    def db_connect(dsn: str):
+        return psycopg.connect(dsn)
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    datefmt="%H:%M:%S",
+)
+logger = logging.getLogger(__name__)
+
+# Azure SDK 로그 억제
+import logging as _logging
+_logging.getLogger("azure").setLevel(_logging.WARNING)
+_logging.getLogger("openai").setLevel(_logging.WARNING)
+_logging.getLogger("httpx").setLevel(_logging.WARNING)
+
+TABLE   = "locallink.gyeonggi_events"
+SRC_COL = "title"
+TGT_COL = "title_en"
+
+_SYSTEM_PROMPT = """\
+You are a professional Korean-to-English translator specializing in cultural event titles.
+
+Rules:
+1. Translate each Korean event title into concise, natural English.
+2. Preserve structural markers exactly as-is: [text], (text), <text>, 《text》, '전시', numbers, dates like (8/30) or (~7/10).
+3. For institution names inside [brackets], translate or romanize them (e.g. [경기도박물관] → [Gyeonggi Museum], [삼성화재모빌리티뮤지엄] → [Samsung Fire Mobility Museum]).
+4. Translate common event types: 전시→Exhibition, 축제→Festival, 공모전→Contest, 학술대회→Conference, 학술회의→Academic Conference, 워크숍→Workshop, 콘서트→Concert, 운영안내→Operation Notice, 휴관→Closed Notice, 모집→Recruitment, 업무협약→MOU Signing, 개소식→Opening Ceremony, 협약식→Agreement Ceremony.
+5. Foreign loanwords written in Korean: 락→Rock, 페스티벌→Festival, 뮤지엄→Museum, 콘서트→Concert, 헤리티지→Heritage, 리빙랩→Living Lab, 홈커밍→Homecoming.
+6. Return ONLY a JSON array of translated strings, same order and count as input. No explanations.
+
+Example input: ["[경기도박물관] 설 연휴 운영안내", "2025 아티즌 락페스티벌 (8/30)"]
+Example output: ["[Gyeonggi Museum] Lunar New Year Holiday Notice", "2025 Artizen Rock Festival (8/30)"]
+"""
+
+# ── Azure OpenAI 클라이언트 ────────────────────────────────────────────────────
+_aoai_client = None
+_aoai_deployment = None
+
+def _get_aoai_client():
+    global _aoai_client, _aoai_deployment
+    if _aoai_client is not None:
+        return _aoai_client, _aoai_deployment
+
+    try:
+        from openai import AzureOpenAI
+    except ImportError:
+        raise ImportError("openai 패키지 미설치 → pip install openai")
+
+    v = get_vault_manager()
+    endpoint   = v.get_secret("azure-openai-endpoint")
+    api_key    = v.get_secret("azure-openai-key")
+    api_ver    = v.get_secret("azure-openai-version") or "2024-02-01"
+    deployment = v.get_secret("azure-openai-deployment-name")
+
+    if not all([endpoint, api_key, deployment]):
+        raise RuntimeError("Key Vault에서 Azure OpenAI 시크릿을 찾을 수 없습니다.")
+
+    _aoai_client = AzureOpenAI(
+        azure_endpoint=endpoint,
+        api_key=api_key,
+        api_version=api_ver,
+    )
+    _aoai_deployment = deployment
+    logger.info("Azure OpenAI 연결 완료 (deployment: %s)", deployment)
+    return _aoai_client, _aoai_deployment
+
+
+def translate_batch(titles: list[str]) -> list[str]:
+    """titles 리스트를 Azure OpenAI로 일괄 번역. 실패 시 원문 반환."""
+    client, deployment = _get_aoai_client()
+
+    user_msg = json.dumps(titles, ensure_ascii=False)
+    try:
+        resp = client.chat.completions.create(
+            model=deployment,
+            messages=[
+                {"role": "system", "content": _SYSTEM_PROMPT},
+                {"role": "user",   "content": user_msg},
+            ],
+            temperature=0.1,
+            max_tokens=4096,
+        )
+        raw = resp.choices[0].message.content.strip()
+        # JSON 배열 추출 (```json ... ``` 래핑 제거)
+        if raw.startswith("```"):
+            raw = raw.split("```")[1]
+            if raw.startswith("json"):
+                raw = raw[4:]
+        result = json.loads(raw)
+        if isinstance(result, list) and len(result) == len(titles):
+            return result
+        logger.warning("응답 건수 불일치 (%d → %d) — 원문 유지", len(titles), len(result))
+        return titles
+    except Exception as e:
+        logger.warning("번역 실패 (%s) — 원문 유지", e)
+        return titles
+
+
+def ensure_column(cursor) -> None:
+    cursor.execute(
+        f"ALTER TABLE {TABLE} ADD COLUMN IF NOT EXISTS {TGT_COL} TEXT;"
+    )
+    logger.info("컬럼 확인 완료: %s.%s", TABLE, TGT_COL)
+
+
+def fetch_all_pending(cursor) -> list[str]:
+    """미처리 고유 title 전체 로드."""
+    cursor.execute(
+        f"""
+        SELECT DISTINCT {SRC_COL}
+        FROM   {TABLE}
+        WHERE  {SRC_COL} IS NOT NULL
+          AND  ({TGT_COL} IS NULL OR {TGT_COL} = '')
+        ORDER  BY {SRC_COL};
+        """
+    )
+    return [row[0] for row in cursor.fetchall()]
+
+
+def run(dsn: str, batch_size: int, commit_size: int, dry_run: bool) -> None:
+    conn = db_connect(dsn)
+    conn.autocommit = False
+
+    try:
+        with conn.cursor() as cur:
+            ensure_column(cur)
+            conn.commit()
+            logger.info("미처리 행사명 로드 중...")
+            titles = fetch_all_pending(cur)
+
+        if not titles:
+            logger.info("보강할 행사 없음 — 종료.")
+            return
+
+        total = len(titles)
+        n_batches = (total + batch_size - 1) // batch_size
+        logger.info("총 %d 건 Azure OpenAI 번역 시작 (%d건 배치 × %d회)...",
+                    total, batch_size, n_batches)
+
+        t0 = time.time()
+
+        # dry-run: 첫 배치(최대 20건)만 번역하고 출력
+        if dry_run:
+            preview = titles[:min(batch_size, 20)]
+            translated = translate_batch(preview)
+            for orig, en in zip(preview, translated):
+                logger.info("[DRY-RUN] %-50s  ->  %s", orig, en)
+            if total > 20:
+                logger.info("... 외 %d 건 (--dry-run: 처음 20건만 표시)", total - 20)
+            return
+
+        # 1단계: OpenAI 배치 번역
+        converted = []   # (title_en, title)
+        for b_idx in range(n_batches):
+            chunk = titles[b_idx * batch_size: (b_idx + 1) * batch_size]
+            translated = translate_batch(chunk)
+            for orig, en in zip(chunk, translated):
+                converted.append((en, orig))
+            logger.info("번역 진행: %d / %d (%.0f%%)",
+                        min((b_idx + 1) * batch_size, total),
+                        total,
+                        min((b_idx + 1) * batch_size, total) / total * 100)
+            time.sleep(0.3)   # rate limit 여유
+
+        elapsed_trans = time.time() - t0
+        logger.info("번역 완료: %d 건 (%.1f초)", total, elapsed_trans)
+
+        # 2단계: 배치 UPDATE (title 기준, id 없음)
+        SQL = (
+            f"UPDATE {TABLE} "
+            f"SET {TGT_COL} = %s "
+            f"WHERE {SRC_COL} = %s "
+            f"AND ({TGT_COL} IS NULL OR {TGT_COL} = '');"
+        )
+
+        total_updated = 0
+        for chunk_start in range(0, total, commit_size):
+            chunk = converted[chunk_start: chunk_start + commit_size]
+            with conn.cursor() as cur:
+                cur.executemany(SQL, chunk)
+                total_updated += cur.rowcount
+            conn.commit()
+
+        elapsed_total = time.time() - t0
+        logger.info(
+            "완료 — 갱신: %d행 / 소요: %.1f초",
+            total_updated, elapsed_total,
+        )
+
+    except Exception:
+        conn.rollback()
+        logger.exception("오류 발생 — 롤백 완료.")
+        raise
+    finally:
+        conn.close()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="행사명 한국어 → 영문명 보강 (Azure OpenAI 번역)"
+    )
+    parser.add_argument("--dsn", required=True, help="PostgreSQL DSN")
+    parser.add_argument(
+        "--batch-size", type=int, default=30,
+        help="OpenAI 1회 요청당 번역 건수 (기본 30)",
+    )
+    parser.add_argument(
+        "--commit-size", type=int, default=500,
+        help="DB 커밋 단위 (기본 500)",
+    )
+    parser.add_argument("--dry-run", action="store_true", help="DB에 쓰지 않고 처음 20건만 출력")
+    args = parser.parse_args()
+
+    run(args.dsn, args.batch_size, args.commit_size, args.dry_run)
+
+
+if __name__ == "__main__":
+    main()
+
+

--- a/scripts/ingest/enrich_restaurant_names_en.py
+++ b/scripts/ingest/enrich_restaurant_names_en.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python
+"""locallink.gg_restaurant_info.bizplc_nm 영문명 보강 (로컬 로마자 변환 전용).
+
+K-Term API 미사용 - 29,000+ 건을 빠르게 처리하기 위해
+  1. 전체 고유 상호명 + 업태를 DB에서 한 번에 로드
+  2. Python에서 로마자 변환 (네트워크 없음, 매우 빠름)
+  3. 1,000건 단위 executemany 배치 UPDATE
+
+변환 형식: 상호명 로마자 (업종 영어)
+  예)  할머니네집, 한식  ->  Halmeoninejip (Korean Restaurant)
+       스타벅스,  까페   ->  Seutabeogseu (Cafe)
+
+Usage:
+    python scripts/ingest/enrich_restaurant_names_en.py \
+        --dsn "host=... dbname=... user=... password=... sslmode=require" \
+        [--commit-size 1000] \
+        [--dry-run]
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+import time
+from pathlib import Path
+from typing import Optional
+
+_ROOT = Path(__file__).resolve().parents[2]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from src.api.kterm_client import romanize_restaurant_fallback  # noqa: E402
+
+try:
+    import psycopg
+    def db_connect(dsn: str):
+        return psycopg.connect(dsn)
+except ModuleNotFoundError:
+    import psycopg2 as psycopg
+    def db_connect(dsn: str):
+        return psycopg.connect(dsn)
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    datefmt="%H:%M:%S",
+)
+logger = logging.getLogger(__name__)
+
+TABLE   = "locallink.gg_restaurant_info"
+SRC_COL = "bizplc_nm"
+TGT_COL = "bizplc_nm_en"
+BIZ_COL = "bizcond_div_nm_info"
+
+
+def ensure_column(cursor) -> None:
+    cursor.execute(
+        f"ALTER TABLE {TABLE} ADD COLUMN IF NOT EXISTS {TGT_COL} TEXT;"
+    )
+    logger.info("컬럼 확인 완료: %s.%s", TABLE, TGT_COL)
+
+
+def fetch_all_pending(cursor) -> list:
+    """미처리 고유 상호명 전체를 (bizplc_nm, bizcond_div_nm_info) 로 로드."""
+    cursor.execute(
+        f"""
+        SELECT DISTINCT ON ({SRC_COL})
+               {SRC_COL},
+               NULLIF(TRIM({BIZ_COL}), '')
+        FROM   {TABLE}
+        WHERE  {SRC_COL} IS NOT NULL
+          AND  ({TGT_COL} IS NULL OR {TGT_COL} = '')
+        ORDER  BY {SRC_COL};
+        """
+    )
+    return [(row[0], row[1]) for row in cursor.fetchall()]
+
+
+def run(dsn: str, commit_size: int, dry_run: bool) -> None:
+    conn = db_connect(dsn)
+    conn.autocommit = False
+
+    try:
+        with conn.cursor() as cur:
+            ensure_column(cur)
+            conn.commit()
+            logger.info("미처리 상호명 로드 중...")
+            rows = fetch_all_pending(cur)
+
+        if not rows:
+            logger.info("보강할 음식점 없음 - 종료.")
+            return
+
+        total = len(rows)
+        logger.info("총 %d 건 로마자 변환 시작 (API 호출 없음)...", total)
+
+        t0 = time.time()
+
+        # 1단계: Python 로컬 변환 (매우 빠름)
+        converted = []   # (name_en, name) - UPDATE 파라미터 순서
+        for name, biz_type in rows:
+            name_en = romanize_restaurant_fallback(name, biz_type)
+            converted.append((name_en, name))
+
+        elapsed_conv = time.time() - t0
+        logger.info("변환 완료: %d 건 (%.1f초)", total, elapsed_conv)
+
+        if dry_run:
+            for name_en, name in converted[:20]:
+                logger.info("[DRY-RUN] %s  ->  %s", name, name_en)
+            if total > 20:
+                logger.info("... 외 %d 건 (--dry-run: 처음 20건만 표시)", total - 20)
+            return
+
+        # 2단계: 배치 UPDATE
+        SQL = (
+            f"UPDATE {TABLE} "
+            f"SET {TGT_COL} = %s "
+            f"WHERE {SRC_COL} = %s "
+            f"AND ({TGT_COL} IS NULL OR {TGT_COL} = '');"
+        )
+
+        total_updated = 0
+        for chunk_start in range(0, total, commit_size):
+            chunk = converted[chunk_start : chunk_start + commit_size]
+            with conn.cursor() as cur:
+                cur.executemany(SQL, chunk)
+                total_updated += cur.rowcount
+            conn.commit()
+            done = min(chunk_start + commit_size, total)
+            logger.info("진행: %d / %d (%.0f%%)", done, total, done / total * 100)
+
+        elapsed_total = time.time() - t0
+        logger.info(
+            "완료 - 갱신: %d행 / 소요: %.1f초 (초당 %.0f건)",
+            total_updated, elapsed_total, total_updated / max(elapsed_total, 1),
+        )
+
+    except Exception:
+        conn.rollback()
+        logger.exception("오류 발생 - 롤백 완료.")
+        raise
+    finally:
+        conn.close()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="음식점명 한국어 -> 로마자 영문명 보강 (로컬 변환, API 미사용)"
+    )
+    parser.add_argument("--dsn", required=True, help="PostgreSQL DSN")
+    parser.add_argument(
+        "--commit-size", type=int, default=1000,
+        help="한 번에 커밋할 행 수 (기본 1000)",
+    )
+    parser.add_argument("--dry-run", action="store_true", help="DB에 쓰지 않고 처음 20건만 출력")
+    args = parser.parse_args()
+
+    run(args.dsn, args.commit_size, args.dry_run)
+
+
+if __name__ == "__main__":
+    main()

--- a/sql/analytics/hybrid_place_matching.sql
+++ b/sql/analytics/hybrid_place_matching.sql
@@ -1,0 +1,208 @@
+-- =============================================================================
+-- 선제적 추천 매칭 쿼리: PostGIS + pgvector 하이브리드
+-- is_indoor 컬럼 없이 쿼리 시점에 리뷰 키워드로 실내/외 동적 판별
+-- =============================================================================
+-- 대상 테이블 (실제 스키마 기준):
+--   locallink.tourist_spot_info       -- 관광지 (lat, lng, tourist_nm)
+--   locallink.gg_restaurant_info      -- 음식점 (refine_wgs84_lat, refine_wgs84_logt)
+--   locallink.attraction_reviews      -- 리뷰 + 임베딩 (embedding vector, clean_text)
+--   locallink.realtime_weather_conditions -- 실시간 날씨 (outdoor_status, pm10, pm25)
+-- =============================================================================
+
+-- -----------------------------------------------------------------------------
+-- 메인 하이브리드 매칭 쿼리
+-- -----------------------------------------------------------------------------
+-- 파라미터 (백엔드에서 바인딩):
+--   :city          VARCHAR  -- 사용자 위치 도시 (예: '수원')
+--   :user_lng      FLOAT    -- 사용자 경도 (예: 126.9990)
+--   :user_lat      FLOAT    -- 사용자 위도 (예: 37.2665)
+--   :radius_m      INT      -- 반경 미터 (예: 5000)
+--   :query_vector  VECTOR   -- 사용자 검색어 임베딩 (예: '[0.12, -0.34, ...]'::vector)
+--   :top_k         INT      -- 최종 후보 수 (예: 3)
+-- -----------------------------------------------------------------------------
+
+WITH
+
+-- 1. 사용자 위치 도시의 최신 날씨
+CurrentWeather AS (
+    SELECT
+        outdoor_status,
+        temperature,
+        pm10,
+        pm25,
+        precipitation_type
+    FROM   locallink.realtime_weather_conditions
+    WHERE  location = :city            -- 파라미터 바인딩
+    ORDER  BY record_time DESC
+    LIMIT  1
+),
+
+-- 2. 관광지 후보: 날씨 필터 + 반경 필터
+-- is_indoor 컬럼 없이, 리뷰 키워드로 쿼리 시점 동적 판별
+AttractionCandidates AS (
+    SELECT
+        t.tourist_nm                                      AS place_name,
+        t.tourist_nm_en                                   AS place_name_en,
+        t.road_addr                                       AS road_address,
+        t.road_addr_en                                    AS road_address_en,
+        t.sigun_nm,
+        t.lat,
+        t.lng,
+        -- [동적 실내/외 판별] 리뷰 키워드 집계 (컬럼 불필요)
+        CASE
+            WHEN EXISTS (
+                SELECT 1 FROM locallink.attraction_reviews r
+                WHERE  r.attraction_name = t.tourist_nm
+                  AND  (   r.clean_text ILIKE ANY(ARRAY['%실내%','%전시관%','%박물관%',
+                                                        '%미술관%','%아쿠아리움%','%센터%',
+                                                        '%문화원%','%도서관%','%비 와도%',
+                                                        '%비가 와도%','%실내 놀이%'])
+                        OR r.extracted_keywords ILIKE ANY(ARRAY['%실내%','%전시%',
+                                                                '%박물관%','%미술관%'])
+                       )
+            ) THEN TRUE
+            WHEN EXISTS (
+                SELECT 1 FROM locallink.attraction_reviews r
+                WHERE  r.attraction_name = t.tourist_nm
+                  AND  (   r.clean_text ILIKE ANY(ARRAY['%등산%','%트레킹%','%야외%',
+                                                        '%공원%','%산책로%','%캠핑%',
+                                                        '%계곡%','%광장%','%야경%'])
+                        OR r.extracted_keywords ILIKE ANY(ARRAY['%야외%','%공원%',
+                                                                '%등산%','%트레킹%'])
+                       )
+            ) THEN FALSE
+            ELSE NULL  -- 리뷰 없거나 판단 불가 → 날씨 무관 항상 포함
+        END                                               AS is_indoor,
+        'attraction'                                      AS place_type,
+        -- PostGIS 거리 계산 (미터)
+        ST_Distance(
+            ST_SetSRID(ST_MakePoint(:user_lng, :user_lat), 4326)::geography,
+            ST_SetSRID(ST_MakePoint(t.lng::float, t.lat::float), 4326)::geography
+        )                                                 AS distance_meters
+    FROM   locallink.tourist_spot_info t
+    WHERE
+        t.lat  IS NOT NULL
+        AND t.lng  IS NOT NULL
+        -- [반경 필터] (날씨 필터보다 먼저 적용해 후보군 사전 축소)
+        AND ST_DWithin(
+            ST_SetSRID(ST_MakePoint(:user_lng, :user_lat), 4326)::geography,
+            ST_SetSRID(ST_MakePoint(t.lng::float, t.lat::float), 4326)::geography,
+            :radius_m
+        )
+),
+
+-- 2-b. 날씨 조건 적용 (동적 is_indoor 판별 후 필터링)
+AttractionFiltered AS (
+    SELECT ac.*
+    FROM   AttractionCandidates ac
+    CROSS  JOIN CurrentWeather cw
+    WHERE
+        -- 악천후 → is_indoor TRUE 또는 판단불가(NULL)만 통과
+        CASE
+            WHEN (
+                cw.outdoor_status IN ('비/눈', '미세먼지 나쁨', '폭염', '한파', '대기 나쁨')
+                OR cw.precipitation_type IN (1, 2, 3)
+                OR cw.pm10  > 80
+                OR cw.pm25  > 35
+                OR cw.temperature > 33
+                OR cw.temperature < -10
+            )
+            THEN ac.is_indoor IS NOT FALSE   -- FALSE(실외) 제외, TRUE·NULL 통과
+            ELSE TRUE                         -- 날씨 쾌적 → 실내외 모두 통과
+        END
+),
+
+-- 3. 음식점 후보: 영업 중 + 반경 필터 (음식점은 날씨 무관 항상 실내 포함)
+RestaurantCandidates AS (
+    SELECT
+        r.bizplc_nm                                       AS place_name,
+        r.bizplc_nm_en                                    AS place_name_en,
+        r.refine_roadnm_addr                              AS road_address,
+        r.refine_roadnm_addr_en                           AS road_address_en,
+        r.sigun_nm,
+        r.refine_wgs84_lat                                AS lat,
+        r.refine_wgs84_logt                               AS lng,
+        TRUE                                              AS is_indoor,  -- 음식점은 항상 실내
+        'restaurant'                                      AS place_type,
+        ST_Distance(
+            ST_SetSRID(ST_MakePoint(:user_lng, :user_lat), 4326)::geography,
+            ST_SetSRID(ST_MakePoint(r.refine_wgs84_logt::float, r.refine_wgs84_lat::float), 4326)::geography
+        )                                                 AS distance_meters
+    FROM   locallink.gg_restaurant_info r
+    WHERE
+        -- 폐업·정지 업소 제외
+        r.bsn_state_nm = '영업'
+        AND r.refine_wgs84_lat  IS NOT NULL
+        AND r.refine_wgs84_logt IS NOT NULL
+        AND ST_DWithin(
+            ST_SetSRID(ST_MakePoint(:user_lng, :user_lat), 4326)::geography,
+            ST_SetSRID(ST_MakePoint(r.refine_wgs84_logt::float, r.refine_wgs84_lat::float), 4326)::geography,
+            :radius_m
+        )
+),
+
+-- 4. 관광지 후보에 리뷰 임베딩 조인 (벡터 유사도용)
+AttractionWithEmbedding AS (
+    SELECT
+        ac.*,
+        -- AttractionFiltered 에서 날씨 필터 완료된 후보만 사용
+        -- 리뷰 임베딩 중 사용자 쿼리와 가장 유사한 것 선택
+        MIN(ar.embedding <-> :query_vector::vector)       AS vector_distance,
+        COUNT(ar.id)                                      AS review_count,
+        -- 대표 리뷰 스니펫 (최신 1건)
+        (
+            SELECT ar2.description
+            FROM   locallink.attraction_reviews ar2
+            WHERE  ar2.attraction_name = ac.place_name
+            ORDER  BY ar2.post_date DESC NULLS LAST
+            LIMIT  1
+        )                                                 AS review_snippet
+    FROM   AttractionFiltered ac
+    LEFT   JOIN locallink.attraction_reviews ar
+           ON  ar.attraction_name = ac.place_name
+           AND ar.embedding IS NOT NULL
+    GROUP  BY
+        ac.place_name, ac.place_name_en, ac.road_address, ac.road_address_en,
+        ac.sigun_nm, ac.lat, ac.lng, ac.is_indoor, ac.place_type, ac.distance_meters
+),
+
+-- 5. 음식점은 리뷰 임베딩 없으므로 거리 기반 점수만 부여
+RestaurantScored AS (
+    SELECT
+        rc.*,
+        NULL::float                                       AS vector_distance,
+        0                                                 AS review_count,
+        NULL::text                                        AS review_snippet
+    FROM   RestaurantCandidates rc
+),
+
+-- 6. 관광지 + 음식점 통합
+AllCandidates AS (
+    SELECT * FROM AttractionWithEmbedding
+    UNION ALL
+    SELECT * FROM RestaurantScored
+)
+
+-- 7. 최종 정렬 및 상위 K개 반환
+SELECT
+    place_name,
+    place_name_en,
+    road_address,
+    road_address_en,
+    sigun_nm,
+    place_type,
+    is_indoor,
+    ROUND(distance_meters::numeric, 0)                   AS distance_m,
+    ROUND(vector_distance::numeric, 4)                   AS similarity_score,
+    review_count,
+    review_snippet
+FROM   AllCandidates
+ORDER BY
+    -- [하이브리드 정렬]
+    -- 임베딩 있는 관광지: 벡터 거리 우선
+    -- 임베딩 없는 음식점: 거리 우선
+    CASE WHEN vector_distance IS NOT NULL
+         THEN vector_distance * 0.7 + (distance_meters / :radius_m) * 0.3
+         ELSE (distance_meters / :radius_m)
+    END ASC
+LIMIT  :top_k;

--- a/src/api/__init__.py
+++ b/src/api/__init__.py
@@ -1,0 +1,1 @@
+# src/api package

--- a/src/api/juso_client.py
+++ b/src/api/juso_client.py
@@ -1,0 +1,239 @@
+"""주소기반산업지원서비스 영문주소 API 클라이언트.
+
+엔드포인트: https://business.juso.go.kr/addrlink/addrEngApi.do
+인증: Key Vault 'juso-api-key' (confmKey)
+
+사용:
+    from src.api.juso_client import translate_address
+    en = translate_address("경기도 용인시 기흥구 상갈로 6")
+    # → "6, Sanggal-ro, Giheung-gu, Yongin-si, Gyeonggi-do"
+"""
+from __future__ import annotations
+
+import logging
+import re
+import urllib.parse
+import urllib.request
+import json
+
+logger = logging.getLogger(__name__)
+logging.getLogger("azure").setLevel(logging.WARNING)
+
+_API_URL = "https://business.juso.go.kr/addrlink/addrEngApi.do"
+_API_KEY_CACHE: str | None = None
+
+# 주소에서 괄호/상세주소 제거 패턴
+# 예) "경기도 수원시 영통구 봉영로 1613, 지1층 (영통동, 남광하우스토리)"
+#   → "경기도 수원시 영통구 봉영로 1613"
+_DETAIL_STRIP = re.compile(r",?\s*(지하?\s*\d*층[^\(]*)?\s*\(.*?\)\s*$")
+_COMMA_STRIP  = re.compile(r",\s*$")
+
+# "[*미고시]", "[폐업]" 등 대괄호 주석 제거
+_ANNOTATION_STRIP = re.compile(r"\s*\[.*?\]\s*$")
+
+# 쉼표 뒤 건물상세(층·호·빌딩명) 모두 제거
+# 예) "아주로 37, 아록빌딩 1층" → "아주로 37"
+# 예) "덕영대로 924, 지하1층"   → "덕영대로 924"
+_POST_COMMA_STRIP = re.compile(r",.*$")
+
+# 도로명+건물번호까지 추출, 이후 건물명/방향어는 extra로 분리
+# 예) "경기도 용인시 수지구 신봉로 7 서봉사지" → ("경기도 용인시 수지구 신봉로 7", "서봉사지")
+_ROAD_NUM_RE = re.compile(r'^(.+?(?:로|길|대로|번길)\s*\d+(?:-\d+)?)(\s+\S.*)?$')
+
+# 도로명 없을 때 동/리/읍/면 단위까지 추출, 이후는 건물명 extra
+# 예) "경기도 용인시 수지구 신봉동 서봉사지" → ("경기도 용인시 수지구 신봉동", "서봉사지")
+_DONG_RE = re.compile(r'^(.+?[가-힣]+(?:동|리|읍|면|가)\b)(\s+[가-힣].*)?$')
+
+# 방향·위치 표기어 → 영문 매핑
+_DIRECTION_MAP: dict = {
+    '앞': 'front',
+    '뒤': 'rear',
+    '옆': 'side',
+    '입구': 'entrance',
+    '출구': 'exit',
+    '근처': 'near',
+    '주변': 'around',
+    '내': 'inside',
+    '건너편': 'across',
+    '사거리': 'intersection',
+    '교차로': 'intersection',
+    '코앞': 'near',
+}
+
+
+def _get_api_key() -> str:
+    global _API_KEY_CACHE
+    if _API_KEY_CACHE:
+        return _API_KEY_CACHE
+    from config.vault_manager import get_vault_manager
+    key = get_vault_manager().get_secret("juso-api-key")
+    if not key:
+        raise RuntimeError("Key Vault에 'juso-api-key' 시크릿이 없습니다.")
+    _API_KEY_CACHE = key
+    return key
+
+
+def _romanize_extra(text: str) -> str | None:
+    """건물명·방향 표기어를 로마자로 변환.
+
+    hangul_romanize 설치 시 완전 로마자 변환, 미설치 시 방향어 매핑만 수행.
+    """
+    text = text.strip()
+    if not text:
+        return None
+
+    # 방향·위치 표기어 단독 → 영문 직접 매핑
+    if text in _DIRECTION_MAP:
+        return _DIRECTION_MAP[text]
+
+    # hangul_romanize 사용 가능하면 로마자 변환
+    try:
+        from hangul_romanize import Transliter          # type: ignore
+        from hangul_romanize.rule import academic       # type: ignore
+        transliter = Transliter(academic)
+        romanized = transliter.translit(text)
+        # 변환 결과 안에 방향어가 있으면 영문으로 교체
+        for kor, eng in _DIRECTION_MAP.items():
+            kor_r = transliter.translit(kor)
+            romanized = romanized.replace(kor_r, eng)
+        return romanized.strip() or None
+    except ImportError:
+        pass
+
+    # 폴백: 방향어가 끝에 붙은 경우만 처리, 나머지는 한글 원문 반환
+    for kor, eng in _DIRECTION_MAP.items():
+        if text.endswith(kor):
+            prefix = text[: -len(kor)].strip()
+            return (f"{prefix} {eng}" if prefix else eng).strip()
+
+    return text  # 마지막 폴백 — 한글 그대로
+
+
+def _romanize_full_fallback(addr: str) -> str | None:
+    """hangul_romanize로 주소 전체를 로마자 변환 (juso API 결과 없을 때 폴백).
+
+    Examples:
+        "경기도 평택시 해군기지"    → "Gyeonggi-do Pyeongtaek-si Haegunkiji"
+        "경기도 평택남부문예회관 앞" → "Gyeonggi-do Pyeongtaek Nambu Munyegwan front"
+    """
+    addr = addr.strip()
+    if not addr:
+        return None
+    try:
+        from hangul_romanize import Transliter          # type: ignore
+        from hangul_romanize.rule import academic       # type: ignore
+        transliter = Transliter(academic)
+        romanized = transliter.translit(addr)
+        # 방향·위치 표기어 영문으로 교체
+        for kor, eng in _DIRECTION_MAP.items():
+            kor_r = transliter.translit(kor)
+            romanized = romanized.replace(kor_r, eng)
+        return romanized.strip().title() or None
+    except ImportError:
+        logger.debug("hangul_romanize 미설치 — 폴백 불가: %s", addr)
+        return None
+
+
+def _split_road_and_extra(addr: str) -> tuple:
+    """주소를 (API 검색용 도로·행정 주소, 부가정보) 쌍으로 분리.
+
+    1순위: 도로명+건물번호 패턴  (로/길/대로/번길 + 숫자)
+    2순위: 동/리/읍/면 단위 패턴 (도로명 없는 주소)
+    3순위: 원문 그대로 사용
+
+    Examples:
+        "경기도 용인시 수지구 신봉로 7 서봉사지"  → ("경기도 용인시 수지구 신봉로 7",   "서봉사지")
+        "경기도 용인시 수지구 신봉동 서봉사지"    → ("경기도 용인시 수지구 신봉동",     "서봉사지")
+        "경기도 평택남부문예회관 앞"              → ("경기도 평택남부문예회관 앞",       "")
+    """
+    addr = addr.strip()
+    addr = _ANNOTATION_STRIP.sub("", addr)   # [*미고시] 등 제거
+    addr = _DETAIL_STRIP.sub("", addr)
+    addr = _COMMA_STRIP.sub("", addr).strip()
+
+    # 1순위: 도로명+건물번호
+    m = _ROAD_NUM_RE.match(addr)
+    if m:
+        road_part = m.group(1).strip()
+        extra     = (m.group(2) or "").strip()
+        return road_part, extra
+
+    # 1-b순위: 쉼표 뒤 건물상세(층·호·빌딩명) 제거 후 재시도
+    # 예) "아주로 37, 아록빌딩 1층" → "아주로 37"
+    addr_trimmed = _POST_COMMA_STRIP.sub("", addr).strip()
+    if addr_trimmed != addr:
+        m = _ROAD_NUM_RE.match(addr_trimmed)
+        if m:
+            return m.group(1).strip(), (m.group(2) or "").strip()
+
+    # 2순위: 동/리/읍/면 단위
+    m = _DONG_RE.match(addr)
+    if m:
+        road_part = m.group(1).strip()
+        extra     = (m.group(2) or "").strip()
+        return road_part, extra
+
+    return addr_trimmed or addr, ""
+
+
+def translate_address(kor_addr: str | None) -> str | None:
+    """한글 도로명주소 → 영문 도로명주소.
+
+    결과 없거나 오류 시 None 반환.
+    """
+    if not kor_addr or kor_addr.strip() in ("", "NaN"):
+        return None
+
+    keyword, extra = _split_road_and_extra(kor_addr)
+    if len(keyword) < 4:
+        return None
+
+    try:
+        api_key = _get_api_key()
+        params = urllib.parse.urlencode({
+            "confmKey":    api_key,
+            "currentPage": 1,
+            "countPerPage": 1,
+            "keyword":     keyword,
+            "resultType":  "json",
+        })
+        url = f"{_API_URL}?{params}"
+        req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0"})
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+
+        common = data.get("results", {}).get("common", {})
+        err_code = common.get("errorCode", "0")
+        if err_code != "0":
+            logger.debug("juso API 오류 [%s] %s | 검색어: %s",
+                         err_code, common.get("errorMessage"), keyword)
+            return None
+
+        jusos = data.get("results", {}).get("juso", [])
+        if not jusos:
+            # juso DB에 없는 주소(군사시설·랜드마크 등) → 로마자 폴백
+            full_addr = keyword + (" " + extra if extra else "")
+            fallback = _romanize_full_fallback(full_addr)
+            if fallback:
+                logger.debug("juso 결과 없음 → 로마자 폴백: %s → %s", full_addr, fallback)
+            return fallback
+
+        road_addr_en = jusos[0].get("roadAddr", "").strip()
+        if not road_addr_en:
+            return None
+        # 부가정보(건물명·방향어)가 있으면 로마자로 변환 후 합산
+        if extra:
+            extra_en = _romanize_extra(extra)
+            if extra_en:
+                return f"{road_addr_en} ({extra_en})"
+        return road_addr_en
+
+    except Exception as exc:
+        logger.debug("translate_address 예외: %s | 입력: %s", exc, keyword)
+        return None
+
+
+def reset_key_cache() -> None:
+    """테스트용 캐시 초기화."""
+    global _API_KEY_CACHE
+    _API_KEY_CACHE = None

--- a/src/api/kterm_client.py
+++ b/src/api/kterm_client.py
@@ -1,0 +1,332 @@
+"""K-Term (국립국어원 온용어) API 클라이언트.
+
+엔드포인트: https://kli.korean.go.kr/term/api/search.do
+파라미터 : key, apiSearchWord, num, sort
+응답 필드: channel.return_object[].resultlist[].translation  (대역어 = 영문명)
+
+일일 요청 제한 주의 — ReturnCode 022 가 반환되면 즉시 중단.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+import time
+from pathlib import Path
+from typing import Optional
+
+import requests
+
+# ── Azure SDK 로그 억제 ─────────────────────────────────────────────────────
+logging.getLogger("azure").setLevel(logging.WARNING)
+logging.getLogger("urllib3").setLevel(logging.WARNING)
+
+# ── 프로젝트 루트 sys.path 등록 ────────────────────────────────────────────
+_ROOT = Path(__file__).resolve().parents[2]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from config.vault_manager import vault as _vault  # noqa: E402
+
+logger = logging.getLogger(__name__)
+
+_ENDPOINT = "https://kli.korean.go.kr/term/api/search.do"
+
+# ── 지리/시설 속성 접미사 → 영어 (긴 접미사부터 매칭) ─────────────────────────
+_GEO_SUFFIXES: list[tuple[str, str]] = [
+    ("국립공원",  "National Park"),
+    ("도립공원",  "Provincial Park"),
+    ("시립공원",  "City Park"),
+    ("자연공원",  "Natural Park"),
+    ("해수욕장",  "Beach"),
+    ("유원지",    "Recreation Area"),
+    ("놀이공원",  "Amusement Park"),
+    ("야영장",    "Campground"),
+    ("전망대",    "Observatory"),
+    ("박물관",    "Museum"),
+    ("미술관",    "Art Museum"),
+    ("도서관",    "Library"),
+    ("경기장",    "Stadium"),
+    ("체육관",    "Gymnasium"),
+    ("유적지",    "Historic Site"),
+    ("문화재",    "Cultural Heritage"),
+    ("저수지",    "Reservoir"),
+    ("온천",      "Hot Spring"),
+    ("동굴",      "Cave"),
+    ("계곡",      "Valley"),
+    ("광장",      "Plaza"),
+    ("폭포",      "Falls"),
+    ("호수",      "Lake"),
+    ("공원",      "Park"),
+    ("산성",      "Fortress"),
+    ("궁궐",      "Palace"),
+    ("항구",      "Harbor"),
+    ("반도",      "Peninsula"),
+    ("평야",      "Plain"),
+    ("산림",      "Forest"),
+    ("시장",      "Market"),
+    ("능",        "Royal Tomb"),
+    ("산",        "Mountain"),
+    ("봉",        "Peak"),
+    ("령",        "Pass"),
+    ("재",        "Pass"),
+    ("강",        "River"),
+    ("천",        "Stream"),
+    ("호",        "Lake"),
+    ("곶",        "Cape"),
+    ("갑",        "Cape"),
+    ("만",        "Bay"),
+    ("포",        "Port"),
+    ("사",        "Temple"),
+    ("절",        "Temple"),
+    ("암",        "Hermitage"),
+    ("궁",        "Palace"),
+    ("성",        "Fortress"),
+    ("역",        "Station"),
+    ("도",        "Island"),
+    ("섬",        "Island"),
+]
+
+
+def romanize_fallback(text: str) -> str:
+    """K-Term 결과 없을 때 국어 로마자 표기 + 지리 속성 영어 변환 폴백.
+
+    예)
+        광교산      →  Gwanggyosan Mountain
+        한강        →  Hangang River
+        수원화성    →  Su-Wonhwaseong Fortress
+        만기사      →  Mangisa Temple
+        광교호수공원 →  Gwanggyohosugongwon Park
+    """
+    try:
+        from hangul_romanize import Transliter
+        from hangul_romanize.rule import academic
+        _tr = Transliter(academic)
+    except ImportError:
+        logger.warning("hangul-romanize 미설치 — 원문 반환: %s", text)
+        return text
+
+    name = text.strip()
+
+    # 긴 접미사부터 체크 (첫 번째 매칭 사용)
+    matched_en = ""
+    for ko_suffix, en_suffix in _GEO_SUFFIXES:
+        if name.endswith(ko_suffix) and len(name) > len(ko_suffix):
+            matched_en = en_suffix
+            break
+
+    romanized = _tr.translit(name).title()
+    result = f"{romanized} {matched_en}".strip() if matched_en else romanized
+    logger.debug("[%s] → fallback 로마자: %s", text, result)
+    return result
+
+_API_KEY_CACHE: Optional[str] = None
+_DAILY_LIMIT_EXCEEDED = False
+
+
+def _get_api_key() -> str:
+    global _API_KEY_CACHE
+    if _API_KEY_CACHE:
+        return _API_KEY_CACHE
+    key = _vault.get_secret("k-term-api-key")
+    if not key:
+        raise RuntimeError("k-term-api-key 가 Key Vault에 없습니다.")
+    _API_KEY_CACHE = key
+    return _API_KEY_CACHE
+
+
+def _parse_channel(data: dict) -> Optional[str]:
+    """API 응답 JSON에서 첫 번째 영문 대역어를 추출."""
+    channel = data.get("channel", {})
+    top_rc = channel.get("returnCode") or channel.get("return_code")
+    raw_ro = channel.get("return_object")
+
+    if isinstance(raw_ro, list):
+        ro = raw_ro[0] if raw_ro else {}
+    elif isinstance(raw_ro, dict):
+        ro = raw_ro
+    else:
+        ro = {}
+
+    return_code = ro.get("returnCode") if isinstance(ro, dict) else None
+    if return_code is None:
+        return_code = top_rc
+
+    global _DAILY_LIMIT_EXCEEDED
+    rc_str = str(return_code) if return_code is not None else ""
+    if rc_str in ("22", "022"):
+        logger.error("일일 요청 한도(022) 초과 — 이후 호출 중단.")
+        _DAILY_LIMIT_EXCEEDED = True
+        return None
+
+    if rc_str not in ("1", ""):
+        logger.debug("returnCode=%s — 결과 없음", rc_str)
+        return None
+
+    result_list = ro.get("resultlist", []) if isinstance(ro, dict) else []
+    if not result_list:
+        return None
+
+    for item in result_list:
+        if not isinstance(item, dict):
+            continue
+        translation: str = (item.get("translation") or "").strip()
+        translation_cc: str = (item.get("translation_cc") or "").lower().strip()
+
+        if not translation:
+            continue
+        if any("\uAC00" <= c <= "\uD7A3" for c in translation):
+            continue
+        if translation_cc and translation_cc not in ("영어", "en", "英語", "영어(영국)", "영어(미국)"):
+            logger.debug("translation_cc=%s — 비영어 건너뜀", translation_cc)
+            continue
+        return translation
+
+    return None
+
+
+def translate(
+    text: str,
+    *,
+    api_key: Optional[str] = None,
+    sleep_sec: float = 0.5,
+    max_retries: int = 3,
+) -> Optional[str]:
+    """한국어 텍스트를 온용어 API로 검색해 첫 번째 영문 대역어를 반환."""
+    global _DAILY_LIMIT_EXCEEDED
+
+    if _DAILY_LIMIT_EXCEEDED:
+        logger.warning("일일 요청 한도 초과 — 이후 호출 모두 건너뜁니다.")
+        return None
+
+    if not text or not text.strip():
+        return None
+
+    if api_key is None:
+        api_key = _get_api_key()
+
+    params = {
+        "key": api_key,
+        "apiSearchWord": text.strip(),
+        "num": "10",
+        "start": "1",
+        "sort": "wt",
+    }
+
+    for attempt in range(1, max_retries + 1):
+        try:
+            resp = requests.get(_ENDPOINT, params=params, timeout=10)
+            resp.raise_for_status()
+        except requests.exceptions.Timeout:
+            logger.warning("[%s] 타임아웃 (시도 %d/%d)", text, attempt, max_retries)
+            time.sleep(sleep_sec * attempt)
+            continue
+        except requests.exceptions.HTTPError as exc:
+            status = exc.response.status_code if exc.response else 0
+            if 500 <= status < 600:
+                logger.warning("[%s] 서버 오류 %d (시도 %d/%d)", text, status, attempt, max_retries)
+                time.sleep(sleep_sec * attempt)
+                continue
+            logger.error("[%s] HTTP 오류 %d — 건너뜀", text, status)
+            return None
+        except requests.exceptions.RequestException as exc:
+            logger.error("[%s] 요청 실패: %s", text, exc)
+            return None
+
+        try:
+            data = resp.json()
+        except ValueError:
+            logger.error("[%s] JSON 파싱 실패 — 응답: %.300s", text, resp.text)
+            return None
+
+        logger.debug("[%s] 원본 응답: %s", text, data)
+
+        result = _parse_channel(data)
+        time.sleep(sleep_sec)
+
+        if _DAILY_LIMIT_EXCEEDED:
+            return None
+
+        if result is None:
+            result = romanize_fallback(text)
+            logger.debug("[%s] K-Term 결과 없음 → 폴백: %s", text, result)
+
+        return result
+
+    logger.warning("[%s] 최대 재시도 초과 — 건너뜀", text)
+    return None
+
+
+# ── 음식점 업태 → 영어 (긴 키부터 매칭) ──────────────────────────────────────
+_BIZ_TYPE_MAP: list[tuple[str, str]] = [
+    ("패스트푸드",   "Fast Food"),
+    ("해산물",     "Seafood Restaurant"),
+    ("삼겹살",     "BBQ Restaurant"),
+    ("갈비",      "Korean BBQ"),
+    ("뷔페",      "Buffet"),
+    ("커피숍",     "Cafe"),
+    ("베이커리",    "Bakery"),
+    ("휴게음식점",   "Snack Bar"),
+    ("일반음식점",   "Restaurant"),
+    ("제과점",     "Bakery"),
+    ("한식",      "Korean Restaurant"),
+    ("일식",      "Japanese Restaurant"),
+    ("중식",      "Chinese Restaurant"),
+    ("양식",      "Western Restaurant"),
+    ("분식",      "Korean Snack Bar"),
+    ("카페",      "Cafe"),
+    ("까페",      "Cafe"),
+    ("커피",      "Cafe"),
+    ("경양식",    "Western Restaurant"),
+    ("치킨",      "Fried Chicken"),
+    ("피자",      "Pizza"),
+    ("횟집",      "Seafood Restaurant"),
+    ("고기",      "BBQ Restaurant"),
+    ("족발",      "Korean Pork Restaurant"),
+    ("냉면",      "Noodle Restaurant"),
+    ("국밥",      "Korean Soup Restaurant"),
+    ("곱창",      "Korean Offal Restaurant"),
+    ("해장국",     "Hangover Soup Restaurant"),
+    ("주점",      "Bar"),
+    ("호프",      "Bar"),
+    ("제과",      "Bakery"),
+]
+
+
+def _map_biz_type(biz_type: str | None) -> str:
+    """업태 한국어 → 영어 레이블. 매칭 없으면 'Restaurant'."""
+    if not biz_type:
+        return "Restaurant"
+    for ko, en in _BIZ_TYPE_MAP:
+        if ko in biz_type:
+            return en
+    return "Restaurant"
+
+
+def romanize_restaurant_fallback(text: str, biz_type: str | None = None) -> str:
+    """K-Term 결과 없을 때 음식점명 → 로마자 + (업종) 형식 폴백.
+
+    예)
+        할머니네 집, 한식   →  Halmeoninejip (Korean Restaurant)
+        스타벅스,  카페     →  Seutabeogseu (Cafe)
+        홍길동치킨, 치킨    →  Honggildongchikin (Fried Chicken)
+    """
+    try:
+        from hangul_romanize import Transliter
+        from hangul_romanize.rule import academic
+        _tr = Transliter(academic)
+    except ImportError:
+        logger.warning("hangul-romanize 미설치 — 원문 반환: %s", text)
+        return text
+
+    romanized = _tr.translit(text.strip()).title()
+    biz_en = _map_biz_type(biz_type)
+    result = f"{romanized} ({biz_en})"
+    logger.debug("[%s] → restaurant fallback: %s", text, result)
+    return result
+
+
+def reset_daily_limit_flag() -> None:
+    """테스트용: 일일 한도 플래그 초기화."""
+    global _DAILY_LIMIT_EXCEEDED
+    _DAILY_LIMIT_EXCEEDED = False


### PR DESCRIPTION
## Summary
관광지·음식점·행사 3개 테이블에 영문명 및 영문주소 컬럼을 추가하고 데이터를 일괄 보강합니다. 다국어 AI 도슨트 응답 및 하이브리드 장소 매칭 쿼리의 영문 출력 기반을 마련합니다.

## Changes
- kterm_client.py — K-Term API 클라이언트 (관광지명 로마자 변환)
- juso_client.py — 주소기반산업지원서비스 영문주소 API 클라이언트 (juso, hangul_romanize 폴백 포함)
- enrich_attraction_names_en.py — `tourist_spot_info.tourist_nm_en` 보강 (247건)
- enrich_restaurant_names_en.py — `gg_restaurant_info.bizplc_nm_en` 보강 (27,573건)
- enrich_event_names_en.py — `gyeonggi_events.title_en` 보강 Azure OpenAI (996건)
- enrich_addresses_en.py — `road_addr_en`, `refine_roadnm_addr_en` 보강 (명소 200건, 음식점 29,494건)
- hybrid_place_matching.sql — PostGIS + pgvector 하이브리드 장소 추천 쿼리
- _validate_hybrid_sql.py — 하이브리드 쿼리 EXPLAIN 검증 스크립트

## Test
- juso API dry-run: 명소 200건 성공률 100% (hangul_romanize 폴백 포함)
- 음식점 29,494건 실패 0건 (잔여 135건은 원본 `'NaN'`)
- `hybrid_place_matching.sql` EXPLAIN 정상 (플랜 43라인, PostGIS·vector 인덱스 활용 확인)

## Related
- closes #76 #77 