### PR TITLE
feat(frontend(web)): local dev setup + realtime air quality dashboard

### DIFF
--- a/src/frontend/web/app.py
+++ b/src/frontend/web/app.py
@@ -37,8 +37,15 @@ def create_app() -> Flask:
     )
     app.secret_key = os.getenv("FLASK_SECRET_KEY", "dev-secret-key")
 
-    # 카카오맵 키를 Jinja2 전역 변수로 주입
-    app.jinja_env.globals["kakao_js_key"] = os.getenv("KAKAO_JS_KEY", "")
+    # 카카오맵 키: 환경변수 우선, 없으면 Key Vault에서 자동 조회
+    kakao_js_key = os.getenv("KAKAO_JS_KEY", "").strip()
+    if not kakao_js_key:
+        try:
+            from config.vault_manager import get_vault_manager
+            kakao_js_key = get_vault_manager().get_secret("kakao-js-key") or ""
+        except Exception:
+            kakao_js_key = ""
+    app.jinja_env.globals["kakao_js_key"] = kakao_js_key
 
     # 앱 버전 (모든 템플릿에서 {{ app_version }} 사용 가능)
     app.jinja_env.globals["app_version"] = _read_version()
@@ -53,11 +60,13 @@ def create_app() -> Flask:
     from src.frontend.web.routes.main_map import main_map_bp
     from src.frontend.web.routes.settings import settings_bp
     from src.frontend.web.routes.ios_api import ios_api_bp
+    from src.frontend.web.routes.dashboard import dashboard_bp
 
     app.register_blueprint(onboarding_bp)
     app.register_blueprint(main_map_bp)
     app.register_blueprint(settings_bp)
     app.register_blueprint(ios_api_bp)
+    app.register_blueprint(dashboard_bp)
 
     return app
 

--- a/src/frontend/web/routes/dashboard.py
+++ b/src/frontend/web/routes/dashboard.py
@@ -1,0 +1,474 @@
+from __future__ import annotations
+
+import logging
+import os
+from datetime import datetime, timedelta, timezone
+
+import psycopg2.extras
+from flask import Blueprint, jsonify, render_template, request
+
+from src.frontend.web.services.db import get_db_connection
+
+dashboard_bp = Blueprint("dashboard", __name__)
+logger = logging.getLogger(__name__)
+
+# ── 33개 수도권 도시 좌표 (카카오맵 버블 표시용) ──────────────────────────
+_CITY_COORDS: dict[str, tuple[float, float]] = {
+    "서울":   (37.5665, 126.9780),
+    "인천":   (37.4563, 126.7052),
+    "수원":   (37.2636, 127.0286),
+    "성남":   (37.4196, 127.1267),
+    "의정부": (37.7381, 127.0344),
+    "안양":   (37.3943, 126.9568),
+    "부천":   (37.5035, 126.7660),
+    "광명":   (37.4786, 126.8640),
+    "평택":   (36.9921, 127.1127),
+    "동두천": (37.9032, 127.0606),
+    "안산":   (37.3219, 126.8309),
+    "고양":   (37.6584, 126.8320),
+    "과천":   (37.4291, 126.9874),
+    "구리":   (37.5943, 127.1298),
+    "남양주": (37.6357, 127.2159),
+    "오산":   (37.1497, 127.0769),
+    "시흥":   (37.3801, 126.8030),
+    "군포":   (37.3616, 126.9354),
+    "의왕":   (37.3447, 126.9685),
+    "하남":   (37.5393, 127.2148),
+    "용인":   (37.2411, 127.1775),
+    "파주":   (37.7599, 126.7099),
+    "이천":   (37.2723, 127.4348),
+    "안성":   (36.9956, 127.2695),
+    "김포":   (37.6151, 126.7156),
+    "화성":   (37.1993, 126.8312),
+    "광주":   (37.4295, 127.2555),
+    "양주":   (37.7852, 127.0459),
+    "포천":   (37.8951, 127.2002),
+    "여주":   (37.2977, 127.6376),
+    "연천":   (38.0961, 127.0748),
+    "가평":   (37.8314, 127.5089),
+    "양평":   (37.4916, 127.4874),
+}
+
+_VALID_LOCATIONS: frozenset[str] = frozenset(_CITY_COORDS.keys())
+
+_STATUS_CATEGORY: dict[str, str] = {
+    "야외활동 쾌적":    "good",
+    "보통":          "fair",
+    "미세먼지 나쁨":   "poor",
+    "미세먼지 매우나쁨": "poor",
+    "비/눈":         "rain",
+}
+
+
+# ── 헬퍼 ──────────────────────────────────────────────────────────────────
+def _pm10_grade(val) -> str:
+    if val is None:
+        return "unknown"
+    v = int(val)
+    if v <= 30:
+        return "good"
+    if v <= 80:
+        return "normal"
+    if v <= 150:
+        return "bad"
+    return "very_bad"
+
+
+def _pm25_grade(val) -> str:
+    if val is None:
+        return "unknown"
+    v = int(val)
+    if v <= 15:
+        return "good"
+    if v <= 35:
+        return "normal"
+    if v <= 75:
+        return "bad"
+    return "very_bad"
+
+
+def _delta_info(current, prev) -> dict:
+    if current is None or prev is None:
+        return {"value": None, "str": "—", "up": None}
+    delta = round(float(current) - float(prev), 1)
+    if delta > 0:
+        arrow = "▲"
+    elif delta < 0:
+        arrow = "▼"
+    else:
+        arrow = "—"
+    return {"value": delta, "str": f"{arrow} {abs(delta)}", "up": delta > 0}
+
+
+def _fmt_ts(ts) -> str:
+    if ts is None:
+        return "—"
+    if isinstance(ts, str):
+        return ts
+    try:
+        return ts.isoformat()
+    except Exception:
+        return str(ts)
+
+
+# ── 라우트 ────────────────────────────────────────────────────────────────
+@dashboard_bp.route("/dashboard")
+def dashboard_view():
+    return render_template("dashboard/index.html")
+
+
+@dashboard_bp.route("/api/dashboard/data")
+def api_dashboard_data():
+    raw_loc = (request.args.get("location") or "").strip()
+    # 허용된 도시명 또는 빈 문자열(전체)만 허용
+    location: str = raw_loc if raw_loc in _VALID_LOCATIONS else ""
+
+    try:
+        conn = get_db_connection()
+        cur = conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor)
+
+        # 1) 33개 도시 최신 레코드 한 방에 (지도 + 도넛 + TOP5)
+        cur.execute("""
+            SELECT DISTINCT ON (location)
+                location, record_time, temperature, pm10, pm25,
+                wind_speed, outdoor_status
+            FROM locallink.realtime_weather_conditions
+            ORDER BY location, record_time DESC
+        """)
+        all_latest = cur.fetchall()
+
+        # 2) KPI 현재값
+        if location:
+            cur.execute("""
+                SELECT temperature, pm10, pm25, wind_speed,
+                       outdoor_status, record_time
+                FROM locallink.realtime_weather_conditions
+                WHERE location = %s
+                ORDER BY record_time DESC
+                LIMIT 1
+            """, (location,))
+            kpi_cur_row = cur.fetchone()
+
+            # KPI 이전값 (직전 30분 윈도우)
+            cur.execute("""
+                SELECT temperature, pm10, pm25, wind_speed
+                FROM locallink.realtime_weather_conditions
+                WHERE location = %s
+                ORDER BY record_time DESC
+                LIMIT 1 OFFSET 1
+            """, (location,))
+            kpi_prv_row = cur.fetchone()
+        else:
+            # 전체 평균: 가장 최신 record_time 윈도우
+            cur.execute("""
+                WITH latest AS (
+                    SELECT MAX(record_time) AS max_t
+                    FROM locallink.realtime_weather_conditions
+                )
+                SELECT
+                    ROUND(AVG(w.temperature)::numeric, 1) AS temperature,
+                    ROUND(AVG(w.pm10)::numeric)           AS pm10,
+                    ROUND(AVG(w.pm25)::numeric)           AS pm25,
+                    ROUND(AVG(w.wind_speed)::numeric, 1)  AS wind_speed,
+                    MAX(w.record_time)                    AS record_time
+                FROM locallink.realtime_weather_conditions w
+                JOIN latest ON w.record_time = latest.max_t
+            """)
+            kpi_cur_row = cur.fetchone()
+
+            # 전체 평균 이전 윈도우
+            cur.execute("""
+                WITH second_time AS (
+                    SELECT DISTINCT record_time
+                    FROM locallink.realtime_weather_conditions
+                    ORDER BY record_time DESC
+                    LIMIT 1 OFFSET 1
+                )
+                SELECT
+                    ROUND(AVG(w.temperature)::numeric, 1) AS temperature,
+                    ROUND(AVG(w.pm10)::numeric)           AS pm10,
+                    ROUND(AVG(w.pm25)::numeric)           AS pm25,
+                    ROUND(AVG(w.wind_speed)::numeric, 1)  AS wind_speed
+                FROM locallink.realtime_weather_conditions w
+                JOIN second_time st ON w.record_time = st.record_time
+            """)
+            kpi_prv_row = cur.fetchone()
+
+        # 3) 12시간 트렌드
+        if location:
+            cur.execute("""
+                SELECT
+                    record_time,
+                    ROUND(temperature::numeric, 1) AS temperature,
+                    pm25
+                FROM locallink.realtime_weather_conditions
+                WHERE location = %s
+                  AND record_time >= NOW() - INTERVAL '12 hours'
+                ORDER BY record_time ASC
+            """, (location,))
+        else:
+            cur.execute("""
+                SELECT
+                    record_time,
+                    ROUND(AVG(temperature)::numeric, 1) AS temperature,
+                    ROUND(AVG(pm25)::numeric)           AS pm25
+                FROM locallink.realtime_weather_conditions
+                WHERE record_time >= NOW() - INTERVAL '12 hours'
+                GROUP BY record_time
+                ORDER BY record_time ASC
+            """)
+        trend_rows = cur.fetchall()
+
+        # 4) Raw data 최근 20개
+        if location:
+            cur.execute("""
+                SELECT location, record_time, temperature,
+                       pm10, pm25, wind_speed, outdoor_status
+                FROM locallink.realtime_weather_conditions
+                WHERE location = %s
+                ORDER BY record_time DESC
+                LIMIT 20
+            """, (location,))
+        else:
+            cur.execute("""
+                SELECT location, record_time, temperature,
+                       pm10, pm25, wind_speed, outdoor_status
+                FROM locallink.realtime_weather_conditions
+                ORDER BY record_time DESC
+                LIMIT 20
+            """)
+        raw_rows = cur.fetchall()
+
+        cur.close()
+        conn.close()
+
+    except Exception:
+        logger.exception("Dashboard data query failed")
+        return jsonify({"error": "데이터 조회 오류가 발생했습니다."}), 500
+
+    # ── 가공 ─────────────────────────────────────────────────────────────
+    kpi_cur = dict(kpi_cur_row) if kpi_cur_row else {}
+    kpi_prv = dict(kpi_prv_row) if kpi_prv_row else {}
+
+    kpi = {
+        "temperature": {
+            "value": kpi_cur.get("temperature"),
+            "delta": _delta_info(kpi_cur.get("temperature"), kpi_prv.get("temperature")),
+            "grade": "neutral",
+        },
+        "pm10": {
+            "value": kpi_cur.get("pm10"),
+            "delta": _delta_info(kpi_cur.get("pm10"), kpi_prv.get("pm10")),
+            "grade": _pm10_grade(kpi_cur.get("pm10")),
+        },
+        "pm25": {
+            "value": kpi_cur.get("pm25"),
+            "delta": _delta_info(kpi_cur.get("pm25"), kpi_prv.get("pm25")),
+            "grade": _pm25_grade(kpi_cur.get("pm25")),
+        },
+        "wind_speed": {
+            "value": kpi_cur.get("wind_speed"),
+            "delta": _delta_info(kpi_cur.get("wind_speed"), kpi_prv.get("wind_speed")),
+            "grade": "neutral",
+        },
+    }
+
+    last_refreshed = _fmt_ts(kpi_cur.get("record_time"))
+
+    # 도넛 차트: outdoor_status 카테고리 집계
+    status_counts: dict[str, int] = {"good": 0, "fair": 0, "poor": 0, "rain": 0}
+    for row in all_latest:
+        cat = _STATUS_CATEGORY.get(row["outdoor_status"] or "", "fair")
+        status_counts[cat] += 1
+
+    donut = {
+        "labels": ["야외활동 쾌적", "보통", "미세먼지 나쁨", "비/눈"],
+        "data":   [
+            status_counts["good"],
+            status_counts["fair"],
+            status_counts["poor"],
+            status_counts["rain"],
+        ],
+        "colors": ["#48BB78", "#ECC94B", "#FC8181", "#90CDF4"],
+    }
+
+    # TOP 5 PM10 도시
+    top5 = sorted(
+        [r for r in all_latest if r["pm10"] is not None],
+        key=lambda r: int(r["pm10"]),
+        reverse=True,
+    )[:5]
+    bar_top5 = [
+        {
+            "location": r["location"],
+            "pm10":     int(r["pm10"]),
+            "pm25":     int(r["pm25"]) if r["pm25"] is not None else 0,
+        }
+        for r in top5
+    ]
+
+    # 꺾은선 트렌드
+    KST = timezone(timedelta(hours=9))
+    trend = {
+        "labels": [
+            (row["record_time"].astimezone(KST).strftime("%H:%M")
+             if hasattr(row["record_time"], "astimezone")
+             else str(row["record_time"])[:16])
+            for row in trend_rows
+        ],
+        "temperature": [
+            float(r["temperature"]) if r["temperature"] is not None else None
+            for r in trend_rows
+        ],
+        "pm25": [
+            int(r["pm25"]) if r["pm25"] is not None else None
+            for r in trend_rows
+        ],
+    }
+
+    # 지도 버블 데이터
+    map_data = []
+    for row in all_latest:
+        coords = _CITY_COORDS.get(row["location"])
+        if not coords:
+            continue
+        map_data.append({
+            "location":     row["location"],
+            "lat":          coords[0],
+            "lng":          coords[1],
+            "pm10":         int(row["pm10"]) if row["pm10"] is not None else 0,
+            "pm25":         int(row["pm25"]) if row["pm25"] is not None else 0,
+            "temperature":  float(row["temperature"]) if row["temperature"] is not None else None,
+            "wind_speed":   float(row["wind_speed"]) if row["wind_speed"] is not None else None,
+            "outdoor_status": row["outdoor_status"] or "",
+            "pm10_grade":   _pm10_grade(row["pm10"]),
+        })
+
+    # Raw data (timestamp → ISO string)
+    raw_data = [
+        {
+            "location":     r["location"],
+            "record_time":  _fmt_ts(r["record_time"]),
+            "temperature":  float(r["temperature"]) if r["temperature"] is not None else None,
+            "pm10":         int(r["pm10"]) if r["pm10"] is not None else None,
+            "pm25":         int(r["pm25"]) if r["pm25"] is not None else None,
+            "wind_speed":   float(r["wind_speed"]) if r["wind_speed"] is not None else None,
+            "outdoor_status": r["outdoor_status"] or "",
+        }
+        for r in raw_rows
+    ]
+
+    return jsonify({
+        "kpi":              kpi,
+        "donut":            donut,
+        "bar_top5":         bar_top5,
+        "trend":            trend,
+        "map_data":         map_data,
+        "raw_data":         raw_data,
+        "locations":        sorted(_VALID_LOCATIONS),
+        "last_refreshed":   last_refreshed,
+        "selected_location": location or "전체",
+    })
+
+
+@dashboard_bp.route("/api/dashboard/narrative", methods=["POST"])
+def api_dashboard_narrative():
+    body = request.get_json(silent=True) or {}
+    kpi      = body.get("kpi") or {}
+    bar_top5 = body.get("bar_top5") or []
+    donut    = body.get("donut") or {}
+    location = (body.get("selected_location") or "전체").strip()
+
+    temp_val  = (kpi.get("temperature") or {}).get("value")
+    pm10_val  = (kpi.get("pm10") or {}).get("value")
+    pm25_val  = (kpi.get("pm25") or {}).get("value")
+    temp_delta_str = (kpi.get("temperature") or {}).get("delta", {}).get("str", "")
+
+    def _fallback() -> str:
+        parts = []
+        if bar_top5:
+            t = bar_top5[0]
+            parts.append(f"현재 PM10 농도가 가장 높은 지역은 {t['location']}({t['pm10']}㎍/㎥)입니다.")
+        if temp_val is not None:
+            td = f" ({temp_delta_str})" if temp_delta_str and temp_delta_str != "—" else ""
+            parts.append(f"선택 지역의 현재 기온은 {temp_val}°C{td}입니다.")
+        if pm10_val is not None:
+            grade_ko = {"good": "좋음", "normal": "보통", "bad": "나쁨", "very_bad": "매우나쁨"}.get(
+                _pm10_grade(pm10_val), "보통"
+            )
+            parts.append(f"PM10 {pm10_val}㎍/㎥(상태: {grade_ko}), PM2.5 {pm25_val}㎍/㎥입니다.")
+        donut_data = donut.get("data") or []
+        if len(donut_data) >= 1:
+            total = sum(donut_data) or 1
+            good_pct = round(donut_data[0] / total * 100)
+            parts.append(f"수도권 {total}개 도시 중 {donut_data[0]}개({good_pct}%)가 야외활동 쾌적 상태입니다.")
+        return " ".join(parts) if parts else "현재 수도권 대기 데이터를 불러오는 중입니다."
+
+    try:
+        from config.vault_manager import get_vault_manager
+        from openai import AzureOpenAI
+
+        vm = get_vault_manager()
+        endpoint   = vm.get_secret("azure-openai-endpoint")
+        key        = vm.get_secret("azure-openai-key")
+        version    = vm.get_secret("azure-openai-version")
+        deployment = vm.get_secret("azure-openai-deployment-name")
+
+        if not all([endpoint, key, version, deployment]):
+            raise ValueError("Azure OpenAI 시크릿 누락")
+
+        # 검증 후 str 타입 보장
+        endpoint   = str(endpoint)
+        key        = str(key)
+        version    = str(version)
+        deployment = str(deployment)
+
+        client = AzureOpenAI(
+            azure_endpoint=endpoint,
+            api_key=key,
+            api_version=version,
+            timeout=5.0,
+        )
+
+        top5_str = ", ".join(
+            f'{b["location"]}({b["pm10"]}㎍/㎥)' for b in bar_top5
+        )
+        donut_data = donut.get("data") or []
+        good_cnt = donut_data[0] if donut_data else 0
+        poor_cnt = donut_data[2] if len(donut_data) > 2 else 0
+        total_cnt = sum(donut_data) if donut_data else 0
+
+        summary = (
+            f"선택 지역: {location}\n"
+            f"현재 기온: {temp_val}°C ({temp_delta_str})\n"
+            f"PM10: {pm10_val}㎍/㎥ / PM2.5: {pm25_val}㎍/㎥\n"
+            f"PM10 상위 5개 도시: {top5_str}\n"
+            f"수도권 {total_cnt}개 도시 중 야외활동 쾌적: {good_cnt}개, 미세먼지 나쁨: {poor_cnt}개"
+        )
+
+        response = client.chat.completions.create(
+            model=deployment,
+            messages=[
+                {
+                    "role": "system",
+                    "content": (
+                        "당신은 수도권 실시간 날씨·대기질 대시보드의 AI 브리핑 도우미입니다. "
+                        "주어진 데이터를 바탕으로 2~3문장의 자연스러운 한국어 브리핑을 작성하세요. "
+                        "수치를 구체적으로 언급하고 야외활동 권장 여부를 포함해 주세요."
+                    ),
+                },
+                {
+                    "role": "user",
+                    "content": f"다음 데이터를 분석하여 브리핑 문장을 작성해 주세요:\n{summary}",
+                },
+            ],
+            max_tokens=200,
+            temperature=0.4,
+        )
+        raw_content = response.choices[0].message.content
+        narrative = raw_content.strip() if raw_content else _fallback()
+    except Exception:
+        logger.info("Azure OpenAI narrative 생성 불가, fallback 사용")
+        narrative = _fallback()
+
+    return jsonify({"narrative": narrative})

--- a/src/frontend/web/services/db.py
+++ b/src/frontend/web/services/db.py
@@ -7,9 +7,18 @@ import psycopg2
 
 def get_db_dsn() -> str:
     db_dsn = (os.getenv("DB_DSN") or "").strip()
-    if not db_dsn:
-        raise RuntimeError("DB_DSN is required.")
-    return db_dsn
+    if db_dsn:
+        return db_dsn
+    # DB_DSN 환경변수 없으면 Key Vault에서 자동 조회 (로컬 개발 시 az login 필요)
+    try:
+        from config.vault_manager import get_vault_manager
+        return get_vault_manager().get_db_dsn()
+    except Exception as e:
+        raise RuntimeError(
+            "DB_DSN 환경변수가 없고 Key Vault 조회도 실패했습니다. "
+            "DB_DSN 환경변수를 설정하거나 Key Vault(KEY_VAULT_URL)를 구성하세요. "
+            f"원인: {e}"
+        ) from e
 
 
 def get_db_connection():

--- a/src/frontend/web/services/docent_service.py
+++ b/src/frontend/web/services/docent_service.py
@@ -420,6 +420,17 @@ def _generate_with_llm(context: dict[str, Any], category: str, language: str, mo
     ).strip()
 
     if not endpoint or not api_key or not api_version or not deployment:
+        try:
+            from config.vault_manager import get_vault_manager
+            _vm = get_vault_manager()
+            endpoint = endpoint or (_vm.get_secret("azure-openai-endpoint") or "").strip()
+            api_key = api_key or (_vm.get_secret("azure-openai-key") or "").strip()
+            api_version = api_version or (_vm.get_secret("azure-openai-version") or "").strip()
+            deployment = deployment or (_vm.get_secret("azure-openai-deployment-name") or "").strip()
+        except Exception:
+            pass
+
+    if not endpoint or not api_key or not api_version or not deployment:
         raise RuntimeError("azure openai config is missing")
 
     llm_timeout = max(3.0, min(_float_env("DOCENT_LLM_TIMEOUT_SEC", 6.0), 20.0))

--- a/src/frontend/web/services/speech_service.py
+++ b/src/frontend/web/services/speech_service.py
@@ -35,6 +35,15 @@ def synthesize_speech_mp3(script: str, language: str) -> bytes:
     speech_region = (os.getenv("AZURE_SPEECH_REGION") or "").strip()
 
     if not speech_key or not speech_region:
+        try:
+            from config.vault_manager import get_vault_manager
+            _vm = get_vault_manager()
+            speech_key = speech_key or (_vm.get_secret("azure-speech-key") or "").strip()
+            speech_region = speech_region or (_vm.get_secret("azure-speech-region") or "").strip()
+        except Exception:
+            pass
+
+    if not speech_key or not speech_region:
         raise SpeechSynthesisError("speech configuration is missing", status_code=503)
 
     endpoint = f"https://{speech_region}.tts.speech.microsoft.com/cognitiveservices/v1"

--- a/src/frontend/web/static/css/dashboard.css
+++ b/src/frontend/web/static/css/dashboard.css
@@ -1,0 +1,349 @@
+/* ================================================================
+   Dashboard — 수도권 실시간 대기질 대시보드
+   ================================================================ */
+
+/* ── 캔버스 배경 ─────────────────────────────────────────────────── */
+.db-canvas {
+  background: #F3F4F6;
+  min-height: calc(100vh - var(--gnb-height));
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  box-sizing: border-box;
+}
+
+/* ── 카드 기본 ───────────────────────────────────────────────────── */
+.db-card {
+  background: #fff;
+  border-radius: 10px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  padding: 1rem 1.25rem;
+  overflow: hidden;
+  box-sizing: border-box;
+}
+
+.db-card__title {
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #718096;
+  margin: 0 0 0.6rem 0;
+}
+
+/* ── Row 1: 헤더 ─────────────────────────────────────────────────── */
+.db-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  padding: 0.9rem 1.25rem;
+}
+
+.db-header__title h1 {
+  font-size: 1.2rem;
+  font-weight: 700;
+  color: #1A202C;
+  margin: 0 0 0.15rem 0;
+}
+
+.db-header__title p {
+  font-size: 0.75rem;
+  color: #718096;
+  margin: 0;
+}
+
+.db-header__controls {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.db-select {
+  border: 1px solid #CBD5E0;
+  border-radius: 6px;
+  padding: 0.35rem 0.65rem;
+  font-size: 0.8rem;
+  color: #2D3748;
+  background: #fff;
+  cursor: pointer;
+  outline: none;
+  min-width: 148px;
+}
+.db-select:focus { border-color: #2B6CB0; }
+
+.db-refresh-btn {
+  border: 1px solid #BEE3F8;
+  border-radius: 6px;
+  padding: 0.35rem 0.8rem;
+  font-size: 0.8rem;
+  color: #2B6CB0;
+  background: #EBF8FF;
+  cursor: pointer;
+  font-weight: 600;
+  transition: background 0.15s;
+  white-space: nowrap;
+}
+.db-refresh-btn:hover { background: #BEE3F8; }
+.db-refresh-btn.loading { opacity: 0.6; cursor: not-allowed; }
+
+.db-last-refreshed {
+  font-size: 0.7rem;
+  color: #A0AEC0;
+  white-space: nowrap;
+}
+
+/* ── Row 2: KPI 카드 ─────────────────────────────────────────────── */
+.db-kpi-row {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1rem;
+}
+
+@media (max-width: 900px) {
+  .db-kpi-row { grid-template-columns: repeat(2, 1fr); }
+}
+@media (max-width: 500px) {
+  .db-kpi-row { grid-template-columns: 1fr 1fr; }
+}
+
+.db-kpi-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  padding: 1rem 1.25rem 0.85rem;
+}
+
+.db-kpi-card__value {
+  font-size: 2.1rem;
+  font-weight: 700;
+  line-height: 1.1;
+  transition: color 0.3s;
+}
+
+.db-kpi-card__unit {
+  font-size: 0.85rem;
+  font-weight: 400;
+  color: #718096;
+  margin-top: -0.1rem;
+}
+
+.db-kpi-card__delta {
+  font-size: 0.75rem;
+  font-weight: 600;
+  min-height: 1rem;
+}
+
+/* 등급 색상 */
+.db-kpi--good    { color: #38A169; }
+.db-kpi--normal  { color: #D69E2E; }
+.db-kpi--bad     { color: #E53E3E; }
+.db-kpi--very_bad { color: #C53030; }
+.db-kpi--neutral { color: #2B6CB0; }
+.db-kpi--unknown { color: #A0AEC0; }
+
+/* 증감 화살표 */
+.db-kpi-card__delta.delta-up   { color: #E53E3E; } /* 미세먼지·기온 상승 = 주의 */
+.db-kpi-card__delta.delta-down { color: #38A169; }
+.db-kpi-card__delta.delta-flat { color: #A0AEC0; }
+
+/* ── Row 3: 본체 (지도 + 우측 컬럼) ──────────────────────────────── */
+.db-main-body {
+  display: grid;
+  grid-template-columns: 6fr 4fr;
+  gap: 1rem;
+}
+
+@media (max-width: 1100px) {
+  .db-main-body { grid-template-columns: 1fr; }
+}
+
+.db-map-card {
+  position: relative;
+  min-height: 420px;
+  padding: 1rem;
+}
+
+#db-map {
+  width: 100%;
+  height: calc(100% - 1.6rem);
+  min-height: 380px;
+  border-radius: 8px;
+}
+
+.db-right-col {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+/* Smart Narrative */
+.db-narrative-card {
+  font-size: 0.85rem;
+  line-height: 1.7;
+  color: #2D3748;
+  border-left: 3px solid #2B6CB0;
+  padding-left: 0.75rem;
+  min-height: 2.5rem;
+}
+
+.db-narrative-spinner {
+  display: inline-block;
+  animation: db-spin 1s linear infinite;
+}
+
+@keyframes db-spin {
+  to { transform: rotate(360deg); }
+}
+
+/* 도넛 / 막대 차트 래퍼 */
+.db-donut-wrap {
+  height: 170px;
+  position: relative;
+}
+
+.db-bar-wrap {
+  height: 155px;
+}
+
+/* ── Row 4: 트렌드 + 테이블 ───────────────────────────────────────── */
+.db-details {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+}
+
+@media (max-width: 900px) {
+  .db-details { grid-template-columns: 1fr; }
+}
+
+.db-trend-title {
+  margin: 0 0 0.45rem 0;
+}
+
+.db-trend-wrap {
+  height: 180px;
+}
+
+/* Raw data 테이블 */
+.db-table-wrap {
+  overflow-y: auto;
+  max-height: 220px;
+}
+
+.db-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.77rem;
+}
+
+.db-table th {
+  position: sticky;
+  top: 0;
+  background: #EDF2F7;
+  color: #4A5568;
+  font-weight: 600;
+  padding: 0.35rem 0.5rem;
+  text-align: left;
+  border-bottom: 1px solid #CBD5E0;
+  white-space: nowrap;
+}
+
+.db-table td {
+  padding: 0.3rem 0.5rem;
+  border-bottom: 1px solid #F7FAFC;
+  color: #2D3748;
+  white-space: nowrap;
+}
+
+.db-table tr:hover td { background: #F7FAFC; }
+
+.db-table__empty {
+  text-align: center;
+  color: #A0AEC0;
+  padding: 1.2rem;
+}
+
+/* 지도 없음 플레이스홀더 */
+.db-map-placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 380px;
+  color: #A0AEC0;
+  font-size: 0.85rem;
+}
+
+/* 상태 뱃지 */
+.db-badge {
+  display: inline-block;
+  padding: 0.12rem 0.45rem;
+  border-radius: 99px;
+  font-size: 0.68rem;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.db-badge--good   { background: #C6F6D5; color: #276749; }
+.db-badge--normal { background: #FEFCBF; color: #744210; }
+.db-badge--bad    { background: #FED7D7; color: #9B2C2C; }
+.db-badge--rain   { background: #BEE3F8; color: #2C5282; }
+.db-badge--grey   { background: #EDF2F7; color: #4A5568; }
+
+/* ── 카카오맵 버블 오버레이 ─────────────────────────────────────── */
+.db-bubble-wrap {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.db-bubble {
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  font-weight: 700;
+  font-size: 0.62rem;
+  text-align: center;
+  opacity: 0.82;
+  border: 2px solid rgba(255, 255, 255, 0.55);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);
+  cursor: pointer;
+  transition: opacity 0.15s, transform 0.15s;
+  overflow: hidden;
+  line-height: 1.15;
+  pointer-events: auto;
+}
+
+.db-bubble:hover {
+  opacity: 1;
+  transform: scale(1.12);
+  z-index: 9999;
+}
+
+/* 버블 툴팁 */
+.db-bubble-tooltip {
+  display: none;
+  position: absolute;
+  bottom: calc(100% + 8px);
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(26, 32, 44, 0.92);
+  color: #fff;
+  border-radius: 8px;
+  padding: 0.45rem 0.7rem;
+  font-size: 0.75rem;
+  pointer-events: none;
+  z-index: 10000;
+  line-height: 1.6;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  min-width: 110px;
+  white-space: nowrap;
+}
+
+.db-bubble-wrap:hover .db-bubble-tooltip { display: block; }

--- a/src/frontend/web/static/js/dashboard.js
+++ b/src/frontend/web/static/js/dashboard.js
@@ -1,0 +1,502 @@
+/* =============================================================
+   dashboard.js — 수도권 실시간 대기질 대시보드
+   Chart.js + 카카오맵 버블 오버레이
+   ============================================================= */
+(function () {
+  'use strict';
+
+  /* ── 상수 ────────────────────────────────────────────────── */
+  const STATUS_COLORS = {
+    '야외활동 쾌적':    '#48BB78',
+    '보통':          '#ECC94B',
+    '미세먼지 나쁨':   '#FC8181',
+    '미세먼지 매우나쁨': '#E53E3E',
+    '비/눈':         '#90CDF4',
+  };
+  const DEFAULT_BUBBLE_COLOR = '#CBD5E0';
+
+  /* ── 상태 ────────────────────────────────────────────────── */
+  let donutChart   = null;
+  let barChart     = null;
+  let lineChart    = null;
+  let kakaoMap     = null;
+  let bubbleOverlays = [];
+  let currentData  = null;
+  let isFetching   = false;
+
+  /* ── DOM 참조 ─────────────────────────────────────────────── */
+  const locationSel    = document.getElementById('db-location-sel');
+  const refreshBtn     = document.getElementById('db-refresh-btn');
+  const lastRefreshed  = document.getElementById('db-last-refreshed');
+  const narrativeEl    = document.getElementById('db-narrative-text');
+
+  /* ── 초기화 ───────────────────────────────────────────────── */
+  function init() {
+    if (locationSel) {
+      locationSel.addEventListener('change', fetchData);
+    }
+    if (refreshBtn) {
+      refreshBtn.addEventListener('click', function () {
+        if (!isFetching) {
+          fetchData();
+        }
+      });
+    }
+    fetchData();
+  }
+
+  /* ── 데이터 fetch ─────────────────────────────────────────── */
+  function fetchData() {
+    if (isFetching) return;
+    isFetching = true;
+    if (refreshBtn) {
+      refreshBtn.classList.add('loading');
+      refreshBtn.textContent = '↻ 갱신 중...';
+    }
+
+    const loc = locationSel ? locationSel.value : '';
+    const qs  = loc ? '?location=' + encodeURIComponent(loc) : '';
+
+    fetch('/api/dashboard/data' + qs)
+      .then(function (r) { return r.json(); })
+      .then(function (data) {
+        currentData = data;
+        populateLocationSelector(data.locations, loc || data.selected_location);
+        renderAll(data);
+        fetchNarrative(data);
+      })
+      .catch(function (err) {
+        console.error('[Dashboard] fetch error:', err);
+      })
+      .finally(function () {
+        isFetching = false;
+        if (refreshBtn) {
+          refreshBtn.classList.remove('loading');
+          refreshBtn.textContent = '↻ 새로고침';
+        }
+      });
+  }
+
+  /* ── 지역 슬라이서 채우기 ─────────────────────────────────── */
+  function populateLocationSelector(locations, selectedLoc) {
+    if (!locationSel || locationSel.dataset.populated === 'true') return;
+    locationSel.dataset.populated = 'true';
+
+    // 기존 옵션 유지 (전체 수도권 option value="")
+    locations.forEach(function (loc) {
+      const opt = document.createElement('option');
+      opt.value = loc;
+      opt.textContent = loc;
+      if (loc === selectedLoc) opt.selected = true;
+      locationSel.appendChild(opt);
+    });
+  }
+
+  /* ── 전체 렌더링 ──────────────────────────────────────────── */
+  function renderAll(data) {
+    renderKpi(data.kpi);
+    renderDonut(data.donut);
+    renderBar(data.bar_top5);
+    renderLine(data.trend, data.selected_location);
+    renderTable(data.raw_data);
+    updateLastRefreshed(data.last_refreshed);
+    if (kakaoMap !== null) {
+      updateBubbles(data.map_data);
+    }
+  }
+
+  /* ── KPI 카드 ─────────────────────────────────────────────── */
+  function renderKpi(kpi) {
+    renderKpiCard('kpi-temperature', kpi.temperature, '°C',    /* reverseDelta */ false);
+    renderKpiCard('kpi-pm10',        kpi.pm10,        '㎍/㎥', /* reverseDelta */ true);
+    renderKpiCard('kpi-pm25',        kpi.pm25,        '㎍/㎥', /* reverseDelta */ true);
+    renderKpiCard('kpi-wind',        kpi.wind_speed,  'm/s',   /* reverseDelta */ false);
+  }
+
+  function renderKpiCard(cardId, item, unit, reverseDelta) {
+    var card = document.getElementById(cardId);
+    if (!card) return;
+
+    var valEl   = card.querySelector('.db-kpi-card__value');
+    var unitEl  = card.querySelector('.db-kpi-card__unit');
+    var deltaEl = card.querySelector('.db-kpi-card__delta');
+
+    var val   = item.value;
+    var grade = item.grade || 'neutral';
+    var delta = item.delta || {};
+
+    if (valEl) {
+      valEl.textContent = (val !== null && val !== undefined) ? val : '--';
+      valEl.className   = 'db-kpi-card__value db-kpi--' + grade;
+    }
+    if (unitEl) unitEl.textContent = unit;
+
+    if (deltaEl && delta.str && delta.str !== '—') {
+      deltaEl.textContent = delta.str;
+      if (reverseDelta) {
+        // PM10/PM2.5: 오르면 나쁨(빨강), 내리면 좋음(초록)
+        deltaEl.className = 'db-kpi-card__delta ' + (delta.up ? 'delta-up' : 'delta-down');
+      } else {
+        // 기온/풍속: 변화 방향만 표시
+        deltaEl.className = 'db-kpi-card__delta delta-flat';
+      }
+    } else if (deltaEl) {
+      deltaEl.textContent = '';
+      deltaEl.className   = 'db-kpi-card__delta delta-flat';
+    }
+  }
+
+  /* ── 도넛 차트 ────────────────────────────────────────────── */
+  function renderDonut(donut) {
+    var ctx = document.getElementById('db-donut-chart');
+    if (!ctx) return;
+    if (donutChart) { donutChart.destroy(); donutChart = null; }
+
+    donutChart = new Chart(ctx, {
+      type: 'doughnut',
+      data: {
+        labels: donut.labels,
+        datasets: [{
+          data:            donut.data,
+          backgroundColor: donut.colors,
+          borderWidth:     2,
+          borderColor:     '#fff',
+          hoverOffset:     6,
+        }],
+      },
+      options: {
+        responsive:          true,
+        maintainAspectRatio: false,
+        plugins: {
+          legend: {
+            position: 'right',
+            labels: {
+              font:     { size: 10 },
+              padding:  8,
+              boxWidth: 10,
+              color:    '#4A5568',
+            },
+          },
+          tooltip: {
+            callbacks: {
+              label: function (ctx) {
+                var total = ctx.dataset.data.reduce(function (a, b) { return a + b; }, 0);
+                var pct   = total ? Math.round(ctx.raw / total * 100) : 0;
+                return ' ' + ctx.label + ': ' + ctx.raw + '개 도시 (' + pct + '%)';
+              },
+            },
+          },
+        },
+        cutout: '62%',
+      },
+    });
+  }
+
+  /* ── 가로 막대 차트 (TOP 5) ───────────────────────────────── */
+  function renderBar(top5) {
+    var ctx = document.getElementById('db-bar-chart');
+    if (!ctx) return;
+    if (barChart) { barChart.destroy(); barChart = null; }
+
+    var labels   = top5.map(function (d) { return d.location; });
+    var pm10data = top5.map(function (d) { return d.pm10; });
+    var pm25data = top5.map(function (d) { return d.pm25; });
+
+    barChart = new Chart(ctx, {
+      type: 'bar',
+      data: {
+        labels: labels,
+        datasets: [
+          {
+            label:           'PM10',
+            data:            pm10data,
+            backgroundColor: '#F6AD55',
+            borderRadius:    3,
+            barPercentage:   0.6,
+          },
+          {
+            label:           'PM2.5',
+            data:            pm25data,
+            backgroundColor: '#FC8181',
+            borderRadius:    3,
+            barPercentage:   0.6,
+          },
+        ],
+      },
+      options: {
+        indexAxis:           'y',
+        responsive:          true,
+        maintainAspectRatio: false,
+        plugins: {
+          legend: {
+            position: 'top',
+            labels:   { font: { size: 9 }, boxWidth: 9, padding: 6, color: '#4A5568' },
+          },
+          tooltip: {
+            callbacks: {
+              label: function (ctx) {
+                return ' ' + ctx.dataset.label + ': ' + ctx.raw + ' ㎍/㎥';
+              },
+            },
+          },
+        },
+        scales: {
+          x: {
+            stacked: false,
+            ticks:   { font: { size: 9 }, color: '#718096' },
+            grid:    { color: '#EDF2F7' },
+          },
+          y: {
+            ticks: { font: { size: 10 }, color: '#2D3748' },
+            grid:  { display: false },
+          },
+        },
+      },
+    });
+  }
+
+  /* ── 꺾은선 차트 (12시간 트렌드) ─────────────────────────── */
+  function renderLine(trend, locationLabel) {
+    var ctx = document.getElementById('db-line-chart');
+    if (!ctx) return;
+
+    var titleEl = document.getElementById('db-trend-title');
+    if (titleEl) {
+      titleEl.textContent = '[' + locationLabel + '] 최근 12시간 기온 / PM2.5 추이';
+    }
+
+    if (lineChart) { lineChart.destroy(); lineChart = null; }
+
+    lineChart = new Chart(ctx, {
+      type: 'line',
+      data: {
+        labels: trend.labels,
+        datasets: [
+          {
+            label:           '기온(°C)',
+            data:            trend.temperature,
+            borderColor:     '#4299E1',
+            backgroundColor: 'rgba(66,153,225,0.07)',
+            tension:         0.3,
+            yAxisID:         'y',
+            pointRadius:     2,
+            borderWidth:     2,
+          },
+          {
+            label:           'PM2.5(㎍/㎥)',
+            data:            trend.pm25,
+            borderColor:     '#FC8181',
+            backgroundColor: 'rgba(252,129,129,0.07)',
+            tension:         0.3,
+            yAxisID:         'y1',
+            pointRadius:     2,
+            borderWidth:     2,
+          },
+        ],
+      },
+      options: {
+        responsive:          true,
+        maintainAspectRatio: false,
+        interaction:         { mode: 'index', intersect: false },
+        plugins: {
+          legend: { labels: { font: { size: 9 }, boxWidth: 9, padding: 8, color: '#4A5568' } },
+        },
+        scales: {
+          y: {
+            position: 'left',
+            ticks:    { font: { size: 9 }, color: '#718096' },
+            title:    { display: true, text: '°C', font: { size: 9 }, color: '#4299E1' },
+            grid:     { color: '#EDF2F7' },
+          },
+          y1: {
+            position: 'right',
+            grid:     { drawOnChartArea: false },
+            ticks:    { font: { size: 9 }, color: '#718096' },
+            title:    { display: true, text: '㎍/㎥', font: { size: 9 }, color: '#FC8181' },
+          },
+          x: {
+            ticks: { font: { size: 8 }, maxRotation: 0, color: '#718096' },
+            grid:  { color: '#EDF2F7' },
+          },
+        },
+      },
+    });
+  }
+
+  /* ── Raw Data 테이블 ──────────────────────────────────────── */
+  function renderTable(rawData) {
+    var tbody = document.getElementById('db-table-body');
+    if (!tbody) return;
+
+    if (!rawData || rawData.length === 0) {
+      tbody.innerHTML = '<tr><td colspan="7" style="text-align:center;color:#A0AEC0;padding:1rem;">데이터 없음</td></tr>';
+      return;
+    }
+
+    tbody.innerHTML = rawData.map(function (r) {
+      var badgeClass = getStatusBadgeClass(r.outdoor_status);
+      var timeStr    = formatRecordTime(r.record_time);
+      return [
+        '<tr>',
+          '<td>', r.location, '</td>',
+          '<td>', timeStr, '</td>',
+          '<td>', r.temperature !== null ? r.temperature + '°' : '—', '</td>',
+          '<td>', r.pm10 !== null ? r.pm10 : '—', '</td>',
+          '<td>', r.pm25 !== null ? r.pm25 : '—', '</td>',
+          '<td>', r.wind_speed !== null ? r.wind_speed : '—', '</td>',
+          '<td><span class="db-badge ', badgeClass, '">', r.outdoor_status || '—', '</span></td>',
+        '</tr>',
+      ].join('');
+    }).join('');
+  }
+
+  function getStatusBadgeClass(status) {
+    if (!status) return 'db-badge--grey';
+    if (status.indexOf('쾌적') !== -1) return 'db-badge--good';
+    if (status.indexOf('나쁨') !== -1 || status.indexOf('매우') !== -1) return 'db-badge--bad';
+    if (status.indexOf('비') !== -1 || status.indexOf('눈') !== -1) return 'db-badge--rain';
+    return 'db-badge--normal';
+  }
+
+  function formatRecordTime(isoStr) {
+    if (!isoStr || isoStr === '—') return '—';
+    try {
+      var d = new Date(isoStr);
+      return d.toLocaleString('ko-KR', {
+        timeZone:  'Asia/Seoul',
+        month:     '2-digit',
+        day:       '2-digit',
+        hour:      '2-digit',
+        minute:    '2-digit',
+        hour12:    false,
+      });
+    } catch (e) {
+      return isoStr.slice(0, 16);
+    }
+  }
+
+  /* ── 마지막 갱신 시각 ─────────────────────────────────────── */
+  function updateLastRefreshed(isoStr) {
+    if (!lastRefreshed) return;
+    if (!isoStr || isoStr === '—') { lastRefreshed.textContent = ''; return; }
+    try {
+      var d = new Date(isoStr);
+      var hhmm = d.toLocaleString('ko-KR', {
+        timeZone: 'Asia/Seoul',
+        hour: '2-digit', minute: '2-digit', hour12: false,
+      });
+      lastRefreshed.textContent = '데이터 기준: ' + hhmm + ' (KST) · 15분 전 갱신(개념적, ASA 30분 윈도우)';
+    } catch (e) {
+      lastRefreshed.textContent = isoStr.slice(0, 16);
+    }
+  }
+
+  /* ── 카카오맵 버블 초기화 & 업데이트 ─────────────────────── */
+  function initMap(mapData) {
+    var container = document.getElementById('db-map');
+    if (!container) return;
+    if (typeof kakao === 'undefined' || !kakao.maps) return;
+
+    kakaoMap = new kakao.maps.Map(container, {
+      center: new kakao.maps.LatLng(37.57, 127.10),
+      level:  10,
+    });
+    updateBubbles(mapData);
+  }
+
+  function updateBubbles(mapData) {
+    if (!kakaoMap) return;
+
+    // 기존 오버레이 제거
+    bubbleOverlays.forEach(function (ov) { ov.setMap(null); });
+    bubbleOverlays = [];
+
+    mapData.forEach(function (city) {
+      var color  = STATUS_COLORS[city.outdoor_status] || DEFAULT_BUBBLE_COLOR;
+      var pm10   = city.pm10 || 0;
+      var size   = Math.max(28, Math.min(78, pm10 * 0.65 + 12));
+      var font   = Math.max(8, Math.round(size / 4.2));
+
+      var tooltipLines = [
+        '<strong>' + city.location + '</strong>',
+        '기온: ' + (city.temperature !== null ? city.temperature + '°C' : '—'),
+        'PM10: ' + pm10 + ' ㎍/㎥',
+        'PM2.5: ' + city.pm25 + ' ㎍/㎥',
+        city.outdoor_status || '',
+      ].join('<br>');
+
+      var content = [
+        '<div class="db-bubble-wrap" style="width:', size + 2, 'px;height:', size + 2, 'px;">',
+          '<div class="db-bubble" style="',
+            'width:', size, 'px;',
+            'height:', size, 'px;',
+            'background:', color, ';',
+            'font-size:', font, 'px;',
+          '">',
+            city.location,
+          '</div>',
+          '<div class="db-bubble-tooltip">', tooltipLines, '</div>',
+        '</div>',
+      ].join('');
+
+      var overlay = new kakao.maps.CustomOverlay({
+        position: new kakao.maps.LatLng(city.lat, city.lng),
+        content:  content,
+        yAnchor:  0.5,
+        xAnchor:  0.5,
+      });
+      overlay.setMap(kakaoMap);
+      bubbleOverlays.push(overlay);
+    });
+  }
+
+  /* ── Smart Narrative ──────────────────────────────────────── */
+  function fetchNarrative(data) {
+    if (!narrativeEl) return;
+    narrativeEl.innerHTML = '<span class="db-narrative-spinner">⟳</span> AI 분석 중...';
+
+    fetch('/api/dashboard/narrative', {
+      method:  'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        kpi:               data.kpi,
+        bar_top5:          data.bar_top5,
+        donut:             data.donut,
+        selected_location: data.selected_location,
+      }),
+    })
+      .then(function (r) { return r.json(); })
+      .then(function (res) {
+        narrativeEl.textContent = res.narrative || '데이터를 분석 중입니다.';
+      })
+      .catch(function () {
+        narrativeEl.textContent = 'AI 요약을 일시적으로 불러오지 못했습니다.';
+      });
+  }
+
+  /* ── 엔트리포인트 ─────────────────────────────────────────── */
+  document.addEventListener('DOMContentLoaded', function () {
+    // 이벤트 바인딩
+    if (locationSel) locationSel.addEventListener('change', fetchData);
+    if (refreshBtn)  refreshBtn.addEventListener('click', function () { if (!isFetching) fetchData(); });
+
+    // 카카오맵 병렬 초기화 (지도만 담당 — 데이터 fetch와 독립)
+    if (typeof kakao !== 'undefined' && kakao.maps) {
+      kakao.maps.load(function () {
+        var container = document.getElementById('db-map');
+        if (container) {
+          kakaoMap = new kakao.maps.Map(container, {
+            center: new kakao.maps.LatLng(37.57, 127.10),
+            level:  10,
+          });
+          // 데이터가 이미 로드됐다면 즉시 버블 표시
+          if (currentData) updateBubbles(currentData.map_data);
+        }
+      });
+    }
+
+    // 데이터 fetch (지도와 무관하게 즉시 실행)
+    fetchData();
+  });
+
+})();

--- a/src/frontend/web/templates/base.html
+++ b/src/frontend/web/templates/base.html
@@ -19,6 +19,7 @@
     <a href="/" class="gnb__logo obang-border">LALA</a>
     <div class="gnb__actions">
       <a href="/map" class="gnb__nav-btn" aria-label="Map">{{ t('nav_map') }}</a>
+      <a href="/dashboard" class="gnb__nav-btn" aria-label="Dashboard">대시보드</a>
       <a href="/settings" class="gnb__nav-btn" aria-label="Settings">{{ t('nav_settings') }}</a>
     </div>
   </nav>

--- a/src/frontend/web/templates/dashboard/index.html
+++ b/src/frontend/web/templates/dashboard/index.html
@@ -1,0 +1,156 @@
+{% extends "base.html" %}
+{% block title %}LALA — 수도권 실시간 대기질 대시보드{% endblock %}
+
+{% block head %}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/dashboard.css') }}" />
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.4/dist/chart.umd.min.js"></script>
+{% if kakao_js_key %}
+<script type="text/javascript"
+  src="https://dapi.kakao.com/v2/maps/sdk.js?appkey={{ kakao_js_key }}&autoload=false">
+</script>
+{% endif %}
+{% endblock %}
+
+{% block content %}
+<div class="db-canvas">
+
+  <!-- ══ Row 1: 헤더 & 컨트롤 ══════════════════════════════════ -->
+  <div class="db-card db-header">
+    <div class="db-header__title">
+      <h1>실시간 현황: 수도권</h1>
+      <p>Metropolitan Real-Time Weather &amp; Air Quality</p>
+    </div>
+    <div class="db-header__controls">
+      <select id="db-location-sel" class="db-select" aria-label="지역 선택">
+        <option value="">전체 수도권</option>
+        <!-- JS가 나머지 옵션 채움 -->
+      </select>
+      <button id="db-refresh-btn" class="db-refresh-btn" aria-label="새로고침">↻ 새로고침</button>
+      <span id="db-last-refreshed" class="db-last-refreshed"></span>
+    </div>
+  </div>
+
+  <!-- ══ Row 2: KPI 카드 ══════════════════════════════════════ -->
+  <div class="db-kpi-row">
+
+    <div class="db-card db-kpi-card" id="kpi-temperature">
+      <div class="db-card__title">현재 기온</div>
+      <div class="db-kpi-card__value db-kpi--neutral">--</div>
+      <div class="db-kpi-card__unit">°C</div>
+      <div class="db-kpi-card__delta delta-flat"></div>
+    </div>
+
+    <div class="db-card db-kpi-card" id="kpi-pm10">
+      <div class="db-card__title">PM10 (미세먼지)</div>
+      <div class="db-kpi-card__value db-kpi--neutral">--</div>
+      <div class="db-kpi-card__unit">㎍/㎥</div>
+      <div class="db-kpi-card__delta delta-flat"></div>
+    </div>
+
+    <div class="db-card db-kpi-card" id="kpi-pm25">
+      <div class="db-card__title">PM2.5 (초미세먼지)</div>
+      <div class="db-kpi-card__value db-kpi--neutral">--</div>
+      <div class="db-kpi-card__unit">㎍/㎥</div>
+      <div class="db-kpi-card__delta delta-flat"></div>
+    </div>
+
+    <div class="db-card db-kpi-card" id="kpi-wind">
+      <div class="db-card__title">풍속</div>
+      <div class="db-kpi-card__value db-kpi--neutral">--</div>
+      <div class="db-kpi-card__unit">m/s</div>
+      <div class="db-kpi-card__delta delta-flat"></div>
+    </div>
+
+  </div>
+
+  <!-- ══ Row 3: 지도(6) + 우측 컬럼(4) ══════════════════════ -->
+  <div class="db-main-body">
+
+    <!-- 지도 -->
+    <div class="db-card db-map-card">
+      <div class="db-card__title">수도권 PM10 분포 지도</div>
+      {% if kakao_js_key %}
+        <div id="db-map"></div>
+      {% else %}
+        <div class="db-map-placeholder">
+          지도를 표시하려면 환경변수 <code>KAKAO_JS_KEY</code>를 설정하세요.
+        </div>
+      {% endif %}
+    </div>
+
+    <!-- 우측 컬럼: Smart Narrative + 도넛 + 막대 -->
+    <div class="db-right-col">
+
+      <!-- Smart Narrative -->
+      <div class="db-card">
+        <div class="db-card__title">AI Insight</div>
+        <div class="db-narrative-card" id="db-narrative-text">
+          <span class="db-narrative-spinner">⟳</span> 데이터 로딩 중...
+        </div>
+      </div>
+
+      <!-- 도넛 차트 -->
+      <div class="db-card">
+        <div class="db-card__title">야외활동 상태 분포 (수도권 전체)</div>
+        <div class="db-donut-wrap">
+          <canvas id="db-donut-chart"></canvas>
+        </div>
+      </div>
+
+      <!-- TOP 5 PM10 가로 막대 -->
+      <div class="db-card">
+        <div class="db-card__title">TOP 5 PM10 지역 (㎍/㎥)</div>
+        <div class="db-bar-wrap">
+          <canvas id="db-bar-chart"></canvas>
+        </div>
+      </div>
+
+    </div><!-- /.db-right-col -->
+  </div><!-- /.db-main-body -->
+
+  <!-- ══ Row 4: 트렌드 + Raw Data ════════════════════════════ -->
+  <div class="db-details">
+
+    <!-- 꺾은선 차트 -->
+    <div class="db-card">
+      <div class="db-card__title db-trend-title" id="db-trend-title">
+        최근 12시간 기온 / PM2.5 추이
+      </div>
+      <div class="db-trend-wrap">
+        <canvas id="db-line-chart"></canvas>
+      </div>
+    </div>
+
+    <!-- Raw Data 테이블 -->
+    <div class="db-card">
+      <div class="db-card__title">최근 수집 데이터</div>
+      <div class="db-table-wrap">
+        <table class="db-table">
+          <thead>
+            <tr>
+              <th>지역</th>
+              <th>기준시간</th>
+              <th>기온</th>
+              <th>PM10</th>
+              <th>PM2.5</th>
+              <th>풍속</th>
+              <th>상태</th>
+            </tr>
+          </thead>
+          <tbody id="db-table-body">
+            <tr>
+              <td colspan="7" class="db-table__empty">로딩 중...</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+  </div><!-- /.db-details -->
+
+</div><!-- /.db-canvas -->
+{% endblock %}
+
+{% block scripts %}
+<script src="{{ url_for('static', filename='js/dashboard.js') }}"></script>
+{% endblock %}


### PR DESCRIPTION
<!--
PR 제목 규칙: type(scope): description
예) feat(function): add eventhub trigger
-->

## Summary
<!-- 한 줄로: 무엇을 왜 변경했는지 -->
- 로컬에서 flask run으로 웹앱을 바로 실행할 수 있도록 환경변수 KV 폴백을 추가하고, 수도권 33개 도시 실시간 기상/대기질 모니터링 대시보드(/dashboard)를 신설합니다.

## Changes
**fix(config): KV fallback for local dev secrets**
- services/db.py: `DB_DSN` 없으면 vault.get_db_dsn() 자동 폴백
- `app.py`: `KAKAO_JS_KEY` 없으면 KV kakao-js-key 폴백
- services/docent_service.py: `AZURE_OPENAI_*` 없으면 KV 폴백
- services/speech_service.py: `AZURE_SPEECH_*` 없으면 KV 폴백

**feat(frontend(web)): realtime air quality dashboard**
- `routes/dashboard.py`: `GET /dashboard`, GET /api/dashboard/data, `POST /api/dashboard/narrative`
- templates/dashboard/index.html: 4행 Z-Pattern 레이아웃
- `static/css/dashboard.css`: 카드 스타일, KPI 등급 색상, 반응형
- `static/js/dashboard.js`: Chart.js 3종 + 카카오맵 버블 오버레이
- templates/base.html: GNB 대시보드 링크 추가

## Test
<!-- 실행한 테스트/확인 (없으면 N/A) -->
- GET /api/dashboard/data 응답 확인: 기온 -1.9°C, PM10 30, PM25 20, TOP5 정상 반환
- KV 폴백 검증: `kakao_js_key` 길이 32, `DB_DSN` KV 조회 정상
- 로컬 flask run --port 5000 환경변수 없이 정상 실행 확인

## Related
<!-- 이슈 자동 종료: Closes #번호 -->
- Closes #101 #102 
