### PR TITLE
feat(frontend(web)): 지도 UX·행사·날씨·도슨트·TourAPI 통합 개선

### DIFF
--- a/docs/lala-map-ux-improvements-2026-03-08.md
+++ b/docs/lala-map-ux-improvements-2026-03-08.md
@@ -1,0 +1,150 @@
+# LALA Map UX 개선 — 2026-03-08
+
+> 브랜치: `feat/local-dev-dashboard`
+> 커밋 범위: `src/frontend/web/` 하위 파일 5개
+
+---
+
+## 1. 변경 목록
+
+### 1-1. 시트 열릴 때 카드 패널 + 자막 패널 동시 숨기기
+
+**파일**: `map_logic.js`, `layout.css`
+
+**문제**: 마커/카드 클릭 → 상세 시트(bottom-sheet)가 열려도 상단 카드 패널과 하단 도슨트 자막 패널이 그대로 겹쳐 표시됨.
+
+**해결**:
+- `openSheet()` — `#card-panel`, `#status-panel` 모두 `.hidden` 클래스 추가
+- `closeSheets()` — `.hidden` 클래스 제거 (복원)
+- CSS `.map-subtitle-panel.hidden` 신규 추가 (`opacity:0`, `visibility:hidden`, `transition 0.22s`)
+- 기존 `.map-card-panel.hidden` 동일 패턴 활용
+
+```js
+// openSheet()
+const cardPanel = document.getElementById('card-panel');
+if (cardPanel) cardPanel.classList.add('hidden');
+const subtitlePanel = document.getElementById('status-panel');
+if (subtitlePanel) subtitlePanel.classList.add('hidden');
+```
+
+---
+
+### 1-2. 카드 썸네일 이미지 깨짐 처리
+
+**파일**: `map_logic.js`
+
+**문제**: `place.image_url`이 있어도 실제 이미지 로드 실패 시 깨진 아이콘 + alt 텍스트가 회색 박스 안에 그대로 노출됨.
+
+**해결**: `<img>` 태그에 `onerror` 핸들러 추가 — 로드 실패 시 요소 자체를 숨김.
+
+```js
+`<img class="place-card__thumb" src="${escapeHtml(place.image_url)}"
+     alt="${escapeHtml(placeName(place))}"
+     onerror="this.style.display='none'" />`
+```
+
+---
+
+### 1-3. 자동 도슨트 ON/OFF 시각적 강화
+
+**파일**: `map_logic.js`, `layout.css`
+
+**문제**: ON/OFF 상태가 텍스트("ON"/"OFF")만으로 구분되어 시각적 피드백이 약함.
+
+**해결**:
+- **ON**: 배경색 강조(`--obang-east`) + 파란 글로우 링(`box-shadow`) + `scale(1.06)` + 이모지 `✨`
+- **OFF**: 어두운 배경 유지 + 이모지 `⏸`
+- `transition: background 0.25s, box-shadow 0.25s, transform 0.18s` — 부드러운 전환
+
+```css
+.fab-circle.auto.active {
+  background: var(--obang-east);
+  box-shadow: 0 0 0 4px rgba(var(--obang-east-rgb, 59,130,246), 0.28),
+              0 6px 20px rgba(16, 24, 40, 0.38);
+  transform: scale(1.06);
+}
+```
+
+```js
+if (iconSpan) iconSpan.textContent = APP.isAutoDocentEnabled ? '✨' : '⏸';
+```
+
+---
+
+### 1-4. 카드 가로 스와이프 CSS 버그 수정
+
+**파일**: `layout.css`
+
+**문제**: `.map-card-panel {}` 블록 중간에 `}`가 잘못 삽입되어 `display:flex`, `overflow-x:auto` 등 속성이 선택자 밖에 떠돌아 카드가 세로 나열됨.
+
+**해결**: 모든 속성을 `.map-card-panel {}` 블록 안으로 통합.
+
+---
+
+### 1-5. 도슨트 자막 텍스트 5줄 스크롤 제한
+
+**파일**: `layout.css`
+
+**문제**: 긴 도슨트 텍스트 수신 시 자막 패널이 위로 무한 확장되어 지도 UI를 덮음.
+
+**해결**: `.map-subtitle-text`에 최대 높이 + 스크롤 적용, 버튼은 패널 하단 항상 고정.
+
+```css
+.map-subtitle-text {
+  max-height: calc(1.6em * 5);   /* 5줄 제한 */
+  overflow-y: auto;
+  scrollbar-width: thin;
+}
+```
+
+---
+
+### 1-6. 카드 단일 클릭 → 상세 시트 즉시 열기
+
+**파일**: `map_logic.js`
+
+**문제**: 상세 시트를 열려면 더블클릭이 필요했음.
+
+**해결**: `buildCard()` 클릭 핸들러를 단일 클릭으로 변경. 이미 선택된 카드 재클릭 시 시트 토글(닫힘).
+
+```js
+wrapper.addEventListener('click', () => {
+  const alreadySelected = APP.selectedPlace && APP.selectedPlace.id === place.id;
+  selectPlace(place, { from: 'card', openDetail: !alreadySelected });
+});
+```
+
+---
+
+### 1-7. Contentsquare 추적 스크립트 삽입
+
+**파일**: `base.html`, `app.py`
+
+- `base.html` `</head>` 직전에 Contentsquare 스크립트 `async` 삽입
+- `app.py`에서 Hotjar 잔재 코드 제거
+
+```html
+<script src="https://t.contentsquare.net/uxa/34e2b3fc07281.js" async></script>
+```
+
+> **주의**: Contentsquare는 배포 환경(https)에서만 실제 데이터를 수집합니다. 로컬(http)에서는 수집되지 않습니다.
+
+---
+
+## 2. 수정된 파일 요약
+
+| 파일 | 변경 내용 |
+|------|-----------|
+| `src/frontend/web/app.py` | Hotjar 잔재 코드 제거 |
+| `src/frontend/web/static/css/layout.css` | 카드 스와이프 버그 수정, 도슨트 텍스트 5줄 제한, 시트 hidden 전환, 도슨트 버튼 ON/OFF 글로우 |
+| `src/frontend/web/static/js/map_logic.js` | 카드 단일 클릭, 시트 열릴 때 패널 숨기기, 이미지 onerror, 도슨트 토글 아이콘 |
+| `src/frontend/web/templates/base.html` | Contentsquare 스크립트 삽입 |
+| `src/frontend/web/templates/map/index.html` | 상세 시트 이미지 onerror 처리 |
+
+---
+
+## 3. 삭제된 파일
+
+| 파일 | 이유 |
+|------|------|
+| `scripts/capture_screenshots.py` | 테스트용 스크린샷 자동화 스크립트 — 더 이상 불필요 |

--- a/scripts/ingest/fetch_tourapi_events.py
+++ b/scripts/ingest/fetch_tourapi_events.py
@@ -6,6 +6,13 @@
     python scripts/ingest/fetch_tourapi_events.py --start 20260101  # 시작일 지정
     python scripts/ingest/fetch_tourapi_events.py --dry-run          # DB 미적재, 결과만 출력
 
+[NOTE] 수원시 일부 행사 데이터는 수동으로 직접 INSERT 되었습니다.
+       사유: 본 스크립트 최초 실행 시점(2026-03-08) 기준 실제 진행 중인 행사가 없어
+             웹앱 지도에 행사 핀이 전혀 표시되지 않는 문제가 있었습니다.
+             이를 확인 및 시연 목적으로 begin_de/end_de 범위를 현재 날짜로 맞춘
+             테스트성 행사 레코드를 수동 삽입하였습니다.
+             실제 서비스 시에는 해당 레코드를 삭제하거나 이 스크립트로 재수집 후 대체하세요.
+
 소스: 한국관광공사 TourAPI 4.0
   Base URL : https://apis.data.go.kr/B551011/KorService2
   Endpoint : GET /searchFestival2

--- a/scripts/ingest/fetch_tourapi_events.py
+++ b/scripts/ingest/fetch_tourapi_events.py
@@ -31,7 +31,12 @@ import re
 import sys
 import time
 from datetime import date, datetime
+from pathlib import Path
 from typing import Any
+
+_ROOT = Path(__file__).resolve().parents[2]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
 
 import requests
 
@@ -142,7 +147,6 @@ def _fetch_page(service_key: str, page_no: int, event_start_date: str) -> dict:
         "MobileOS":        MOBILE_OS,
         "MobileApp":       MOBILE_APP,
         "_type":           "json",
-        "listYN":          "Y",
         "arrange":         "D",       # 수정일 내림차순
         "areaCode":        AREA_CODE,
         "eventStartDate":  event_start_date,

--- a/scripts/ingest/fetch_tourapi_events.py
+++ b/scripts/ingest/fetch_tourapi_events.py
@@ -1,0 +1,348 @@
+#!/usr/bin/env python
+"""TourAPI 4.0 경기도 행사 수집 → locallink.gyeonggi_events 적재
+
+사용법:
+    python scripts/ingest/fetch_tourapi_events.py
+    python scripts/ingest/fetch_tourapi_events.py --start 20260101  # 시작일 지정
+    python scripts/ingest/fetch_tourapi_events.py --dry-run          # DB 미적재, 결과만 출력
+
+소스: 한국관광공사 TourAPI 4.0
+  Base URL : https://apis.data.go.kr/B551011/KorService2
+  Endpoint : GET /searchFestival2
+  Key Vault: tour-api-key
+
+응답 → DB 컬럼 매핑
+  title          → title
+  addr1          → inst_nm (장소/주소)
+  eventstartdate → begin_de (YYYY-MM-DD)
+  eventenddate   → end_de   (YYYY-MM-DD)
+  firstimage     → image_url
+  contentid URL  → url
+  createdtime    → writng_de
+  mapy / mapx    → lat / lng  (gyeonggi_events 테이블에 컬럼 필요, migration 참고)
+  addr1 파싱     → city
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import re
+import sys
+import time
+from datetime import date, datetime
+from typing import Any
+
+import requests
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    datefmt="%H:%M:%S",
+)
+logger = logging.getLogger(__name__)
+
+logging.getLogger("azure").setLevel(logging.WARNING)
+logging.getLogger("urllib3").setLevel(logging.WARNING)
+
+# ── 상수 ─────────────────────────────────────────────────────────────────────
+BASE_URL    = "https://apis.data.go.kr/B551011/KorService2/searchFestival2"
+AREA_CODE   = "31"          # 경기도
+NUM_OF_ROWS = 100           # 1회 요청 최대 개수
+MAX_PAGES   = 50            # 안전장치 (최대 5,000건)
+MOBILE_OS   = "ETC"
+MOBILE_APP  = "lala"
+TABLE       = "locallink.gyeonggi_events"
+
+# 경기도 시/군 이름 목록 (addr1에서 city 파싱용)
+GYEONGGI_CITIES: list[tuple[str, str]] = [
+    # (매칭 키워드, DB 저장값)
+    ("수원",   "수원시"),
+    ("성남",   "성남시"),
+    ("고양",   "고양시"),
+    ("용인",   "용인시"),
+    ("부천",   "부천시"),
+    ("안산",   "안산시"),
+    ("안양",   "안양시"),
+    ("남양주", "남양주시"),
+    ("화성",   "화성시"),
+    ("평택",   "평택시"),
+    ("의정부", "의정부시"),
+    ("시흥",   "시흥시"),
+    ("파주",   "파주시"),
+    ("광명",   "광명시"),
+    ("김포",   "김포시"),
+    ("군포",   "군포시"),
+    ("광주",   "광주시"),
+    ("이천",   "이천시"),
+    ("양주",   "양주시"),
+    ("오산",   "오산시"),
+    ("구리",   "구리시"),
+    ("안성",   "안성시"),
+    ("포천",   "포천시"),
+    ("의왕",   "의왕시"),
+    ("하남",   "하남시"),
+    ("여주",   "여주시"),
+    ("양평",   "양평군"),
+    ("동두천", "동두천시"),
+    ("과천",   "과천시"),
+    ("가평",   "가평군"),
+    ("연천",   "연천군"),
+]
+
+# 컬럼이 이미 여기 있는지 여부 — migration을 먼저 실행해야 lat/lng 저장 가능
+_HAS_LATLON_COLS: bool | None = None  # 런타임에 확인
+
+
+def _extract_city(addr: str) -> str:
+    """addr1 주소 문자열에서 경기도 시/군 이름을 추출합니다."""
+    for keyword, city_name in GYEONGGI_CITIES:
+        if keyword in addr:
+            return city_name
+    return "기타"
+
+
+def _fmt_date(yyyymmdd: str | None) -> str | None:
+    """'20260101' → '2026-01-01', 잘못된 형식이면 None 반환."""
+    if not yyyymmdd:
+        return None
+    s = str(yyyymmdd).strip()
+    if re.fullmatch(r"\d{8}", s):
+        return f"{s[:4]}-{s[4:6]}-{s[6:8]}"
+    return None
+
+
+def _safe_float(val: Any) -> float | None:
+    """문자열을 float으로 변환, 실패 시 None."""
+    try:
+        v = float(val)
+        return v if v != 0.0 else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _get_api_key() -> str:
+    """Key Vault(또는 환경변수 TOUR_API_KEY)에서 TourAPI 서비스키를 가져옵니다."""
+    from config.vault_manager import get_vault_manager
+    v = get_vault_manager()
+    key = v.get_secret("tour-api-key")
+    if not key:
+        raise RuntimeError(
+            "TourAPI 키를 찾을 수 없습니다. "
+            "Key Vault에 'tour-api-key' 시크릿이 있는지, "
+            "또는 환경변수 TOUR_API_KEY가 설정됐는지 확인하세요."
+        )
+    return key
+
+
+def _fetch_page(service_key: str, page_no: int, event_start_date: str) -> dict:
+    """searchFestival2 API를 호출해 단일 페이지 결과를 반환합니다."""
+    params = {
+        "serviceKey":      service_key,
+        "MobileOS":        MOBILE_OS,
+        "MobileApp":       MOBILE_APP,
+        "_type":           "json",
+        "listYN":          "Y",
+        "arrange":         "D",       # 수정일 내림차순
+        "areaCode":        AREA_CODE,
+        "eventStartDate":  event_start_date,
+        "numOfRows":       NUM_OF_ROWS,
+        "pageNo":          page_no,
+    }
+    resp = requests.get(BASE_URL, params=params, timeout=30)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def _parse_items(data: dict) -> tuple[list[dict], int]:
+    """API 응답 JSON에서 아이템 목록과 전체 건수를 파싱합니다."""
+    try:
+        body = data["response"]["body"]
+        total_count = int(body.get("totalCount", 0))
+        items_raw = body.get("items", {})
+        if not items_raw or items_raw == "":
+            return [], total_count
+        items = items_raw.get("item", [])
+        if isinstance(items, dict):  # 결과 1건이면 list 아닌 dict
+            items = [items]
+        return items, total_count
+    except (KeyError, TypeError, ValueError) as e:
+        logger.warning("응답 파싱 실패: %s | raw=%s", e, str(data)[:300])
+        return [], 0
+
+
+def _item_to_row(item: dict) -> dict:
+    """API 아이템 1건을 DB INSERT용 dict로 변환합니다."""
+    content_id = str(item.get("contentid", "")).strip()
+    URL = (
+        f"https://korean.visitkorea.or.kr/detail/ms_detail.do?cotid={content_id}"
+        if content_id else ""
+    )
+    addr1 = str(item.get("addr1", "")).strip()
+    created = str(item.get("createdtime", "")).strip()
+    writng_de = _fmt_date(created[:8]) if len(created) >= 8 else None
+
+    return {
+        "inst_nm":   addr1,
+        "title":     str(item.get("title", "")).strip(),
+        "begin_de":  _fmt_date(str(item.get("eventstartdate", ""))),
+        "end_de":    _fmt_date(str(item.get("eventenddate", ""))),
+        "url":       URL,
+        "image_url": str(item.get("firstimage", "")).strip() or None,
+        "writng_de": writng_de,
+        "city":      _extract_city(addr1),
+        "lat":       _safe_float(item.get("mapy")),  # mapy = 위도(lat)
+        "lng":       _safe_float(item.get("mapx")),  # mapx = 경도(lng)
+    }
+
+
+def _check_latlon_columns(cursor) -> bool:
+    """gyeonggi_events 테이블에 lat/lng 컬럼이 있는지 확인합니다."""
+    global _HAS_LATLON_COLS
+    if _HAS_LATLON_COLS is not None:
+        return _HAS_LATLON_COLS
+    cursor.execute(
+        """
+        SELECT COUNT(*) FROM information_schema.columns
+        WHERE table_schema = 'locallink'
+          AND table_name   = 'gyeonggi_events'
+          AND column_name  IN ('lat', 'lng')
+        """
+    )
+    count = cursor.fetchone()[0]
+    _HAS_LATLON_COLS = (count == 2)
+    return _HAS_LATLON_COLS
+
+
+def _bulk_insert(conn, rows: list[dict]) -> int:
+    """rows를 TRUNCATE 후 bulk INSERT 합니다. 성공 건수 반환."""
+    if not rows:
+        return 0
+
+    with conn.cursor() as cur:
+        has_ll = _check_latlon_columns(cur)
+        if has_ll:
+            col_sql = "(inst_nm, title, begin_de, end_de, url, image_url, writng_de, city, lat, lng)"
+            placeholders = "(%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)"
+            values = [
+                (
+                    r["inst_nm"], r["title"], r["begin_de"], r["end_de"],
+                    r["url"], r["image_url"], r["writng_de"], r["city"],
+                    r["lat"], r["lng"],
+                )
+                for r in rows
+            ]
+        else:
+            logger.warning(
+                "lat/lng 컬럼이 없습니다. "
+                "sql/migration/Script-gyeonggi-events-lat-lng-260308.sql 을 먼저 실행하세요. "
+                "좌표 없이 계속 진행합니다."
+            )
+            col_sql = "(inst_nm, title, begin_de, end_de, url, image_url, writng_de, city)"
+            placeholders = "(%s, %s, %s, %s, %s, %s, %s, %s)"
+            values = [
+                (
+                    r["inst_nm"], r["title"], r["begin_de"], r["end_de"],
+                    r["url"], r["image_url"], r["writng_de"], r["city"],
+                )
+                for r in rows
+            ]
+
+        cur.execute(f"TRUNCATE {TABLE}")
+        from psycopg2.extras import execute_batch
+        execute_batch(
+            cur,
+            f"INSERT INTO {TABLE} {col_sql} VALUES {placeholders}",
+            values,
+            page_size=500,
+        )
+        conn.commit()
+        return len(values)
+
+
+def fetch_all_events(service_key: str, event_start_date: str) -> list[dict]:
+    """경기도 행사 전체 페이지를 수집해 row dict 목록을 반환합니다."""
+    all_rows: list[dict] = []
+    total_count = None
+
+    for page in range(1, MAX_PAGES + 1):
+        logger.info("페이지 %d 요청 중...", page)
+        try:
+            data = _fetch_page(service_key, page, event_start_date)
+        except requests.HTTPError as e:
+            logger.error("API 요청 실패: %s", e)
+            break
+
+        items, tc = _parse_items(data)
+        if total_count is None:
+            total_count = tc
+            logger.info("전체 행사 건수: %d건", total_count)
+
+        if not items:
+            logger.info("마지막 페이지 도달 (page=%d)", page)
+            break
+
+        all_rows.extend(_item_to_row(item) for item in items)
+        logger.info("  → 누적 %d건 수집", len(all_rows))
+
+        if len(all_rows) >= (total_count or 0):
+            break
+
+        time.sleep(0.3)  # API 과부하 방지
+
+    return all_rows
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="TourAPI 4.0 경기도 행사 수집 및 DB 적재")
+    parser.add_argument(
+        "--start",
+        default=date.today().strftime("%Y%m%d"),
+        help="행사 시작일 필터 (YYYYMMDD, 기본값: 오늘). "
+             "과거 행사 포함 시 예: --start 20250101",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="DB 적재 없이 수집 결과만 출력",
+    )
+    args = parser.parse_args()
+
+    logger.info("TourAPI 경기도 행사 수집 시작 (eventStartDate=%s)", args.start)
+
+    service_key = _get_api_key()
+    rows = fetch_all_events(service_key, args.start)
+
+    if not rows:
+        logger.warning("수집된 행사 데이터가 없습니다.")
+        sys.exit(0)
+
+    # city 분포 요약
+    city_counts: dict[str, int] = {}
+    for r in rows:
+        city_counts[r["city"]] = city_counts.get(r["city"], 0) + 1
+    logger.info(
+        "city 분포: %s",
+        ", ".join(f"{c}:{n}" for c, n in sorted(city_counts.items(), key=lambda x: -x[1])[:10]),
+    )
+
+    if args.dry_run:
+        logger.info("[dry-run] DB 미적재. 샘플 3건:")
+        for r in rows[:3]:
+            logger.info("  %s", r)
+        sys.exit(0)
+
+    try:
+        from config.vault_manager import get_vault_manager
+        conn = get_vault_manager().get_db_connection()
+        with conn:
+            inserted = _bulk_insert(conn, rows)
+        conn.close()
+        logger.info("완료: %d건 적재 (TRUNCATE 후 전체 재삽입)", inserted)
+    except Exception as e:
+        logger.error("DB 적재 실패: %s", e)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sql/migration/Script-gyeonggi-events-lat-lng-260308.sql
+++ b/sql/migration/Script-gyeonggi-events-lat-lng-260308.sql
@@ -1,0 +1,23 @@
+-- Migration: gyeonggi_events 테이블에 TourAPI 좌표 및 content_id 컬럼 추가
+-- 작성일: 2026-03-08
+-- 목적 : TourAPI 4.0 searchFestival2 수집 데이터 저장용 컬럼 추가
+--        lat / lng  - 행사 장소 좌표 (WGS84)
+--        content_id - 한국관광공사 콘텐츠 ID (향후 upsert 키로 사용 가능)
+-- 선행 조건: locallink.gyeonggi_events 테이블이 존재해야 합니다.
+
+ALTER TABLE locallink.gyeonggi_events
+    ADD COLUMN IF NOT EXISTS lat        DOUBLE PRECISION,
+    ADD COLUMN IF NOT EXISTS lng        DOUBLE PRECISION,
+    ADD COLUMN IF NOT EXISTS content_id TEXT;
+
+-- content_id 에 UNIQUE 인덱스 (NOT NULL 행만 대상)
+CREATE UNIQUE INDEX IF NOT EXISTS idx_gyeonggi_events_content_id
+    ON locallink.gyeonggi_events (content_id)
+    WHERE content_id IS NOT NULL;
+
+COMMENT ON COLUMN locallink.gyeonggi_events.lat IS
+    'WGS84 위도 (TourAPI mapy). 경기도 행사 수집 스크립트가 채웁니다.';
+COMMENT ON COLUMN locallink.gyeonggi_events.lng IS
+    'WGS84 경도 (TourAPI mapx). 경기도 행사 수집 스크립트가 채웁니다.';
+COMMENT ON COLUMN locallink.gyeonggi_events.content_id IS
+    '한국관광공사 TourAPI contentid. visitkorea.or.kr 상세 URL 생성에 활용.';

--- a/src/frontend/web/app.py
+++ b/src/frontend/web/app.py
@@ -60,12 +60,14 @@ def create_app() -> Flask:
     from src.frontend.web.routes.settings import settings_bp
     from src.frontend.web.routes.ios_api import ios_api_bp
     from src.frontend.web.routes.dashboard import dashboard_bp
+    from src.frontend.web.routes.planner import planner_bp
 
     app.register_blueprint(onboarding_bp)
     app.register_blueprint(main_map_bp)
     app.register_blueprint(settings_bp)
     app.register_blueprint(ios_api_bp)
     app.register_blueprint(dashboard_bp)
+    app.register_blueprint(planner_bp)
 
     return app
 

--- a/src/frontend/web/app.py
+++ b/src/frontend/web/app.py
@@ -1,7 +1,7 @@
 import sys
 import os
 from pathlib import Path
-from flask import Flask
+from flask import Flask, jsonify
 from dotenv import load_dotenv
 
 
@@ -68,6 +68,10 @@ def create_app() -> Flask:
     app.register_blueprint(ios_api_bp)
     app.register_blueprint(dashboard_bp)
     app.register_blueprint(planner_bp)
+
+    @app.route("/api/health")
+    def health_check():
+        return jsonify({"status": "ok", "version": app.jinja_env.globals.get("app_version", "unknown")}), 200
 
     return app
 

--- a/src/frontend/web/app.py
+++ b/src/frontend/web/app.py
@@ -47,7 +47,6 @@ def create_app() -> Flask:
             kakao_js_key = ""
     app.jinja_env.globals["kakao_js_key"] = kakao_js_key
 
-    # 앱 버전 (모든 템플릿에서 {{ app_version }} 사용 가능)
     app.jinja_env.globals["app_version"] = _read_version()
 
     # i18n: t() 함수와 current_lang 변수를 모든 템플릿에서 사용 가능하게 주입

--- a/src/frontend/web/routes/ios_api.py
+++ b/src/frontend/web/routes/ios_api.py
@@ -1012,6 +1012,8 @@ def _fetch_places_by_city(
                             COALESCE(city, '') AS region_en,
                             COALESCE(url, '') AS event_url,
                             COALESCE(NULLIF(TRIM(image_url), ''), NULL) AS image_url,
+                            lat,
+                            lng,
                             CASE
                                 WHEN begin_de ~ '^[0-9]{{4}}-[0-9]{{2}}-[0-9]{{2}}$' THEN begin_de::DATE
                                 ELSE NULL
@@ -1029,8 +1031,8 @@ def _fetch_places_by_city(
                         ne.id,
                         ne.name,
                         ne.name_en,
-                        COALESCE(cc.center_lat, %s) AS lat,
-                        COALESCE(cc.center_lng, %s) AS lng,
+                        COALESCE(ne.lat, cc.center_lat, %s) AS lat,
+                        COALESCE(ne.lng, cc.center_lng, %s) AS lng,
                         'event' AS category,
                         ne.address,
                         ne.address_en,
@@ -1040,14 +1042,14 @@ def _fetch_places_by_city(
                             ST_Distance(
                                 ST_SetSRID(ST_MakePoint(%s, %s), 4326)::geography,
                                 ST_SetSRID(
-                                    ST_MakePoint(COALESCE(cc.center_lng, %s), COALESCE(cc.center_lat, %s)),
+                                    ST_MakePoint(COALESCE(ne.lng, cc.center_lng, %s), COALESCE(ne.lat, cc.center_lat, %s)),
                                     4326
                                 )::geography
                             )::NUMERIC,
                             0
                         )::INT AS distance_m,
                         ne.image_url AS image_url,
-                        TRUE AS is_approximate_location,
+                        (ne.lat IS NULL) AS is_approximate_location,
                         ne.event_start_date::TEXT AS event_start_date,
                         ne.event_end_date::TEXT AS event_end_date,
                         ne.event_url,
@@ -1269,6 +1271,8 @@ def _fetch_places(lat: float, lng: float, radius: int, category: str, limit: int
                             COALESCE(city, '') AS region_en,
                             COALESCE(url, '') AS event_url,
                             COALESCE(NULLIF(TRIM(image_url), ''), NULL) AS image_url,
+                            lat,
+                            lng,
                             CASE
                                 WHEN begin_de ~ '^[0-9]{4}-[0-9]{2}-[0-9]{2}$' THEN begin_de::DATE
                                 ELSE NULL
@@ -1285,8 +1289,8 @@ def _fetch_places(lat: float, lng: float, radius: int, category: str, limit: int
                         ne.id,
                         ne.name,
                         ne.name_en,
-                        COALESCE(cc.center_lat, %s) AS lat,
-                        COALESCE(cc.center_lng, %s) AS lng,
+                        COALESCE(ne.lat, cc.center_lat, %s) AS lat,
+                        COALESCE(ne.lng, cc.center_lng, %s) AS lng,
                         'event' AS category,
                         ne.address,
                         ne.address_en,
@@ -1296,14 +1300,14 @@ def _fetch_places(lat: float, lng: float, radius: int, category: str, limit: int
                             ST_Distance(
                                 ST_SetSRID(ST_MakePoint(%s, %s), 4326)::geography,
                                 ST_SetSRID(
-                                    ST_MakePoint(COALESCE(cc.center_lng, %s), COALESCE(cc.center_lat, %s)),
+                                    ST_MakePoint(COALESCE(ne.lng, cc.center_lng, %s), COALESCE(ne.lat, cc.center_lat, %s)),
                                     4326
                                 )::geography
                             )::NUMERIC,
                             0
                         )::INT AS distance_m,
                         ne.image_url AS image_url,
-                        TRUE AS is_approximate_location,
+                        (ne.lat IS NULL) AS is_approximate_location,
                         ne.event_start_date::TEXT AS event_start_date,
                         ne.event_end_date::TEXT AS event_end_date,
                         ne.event_url,
@@ -1314,7 +1318,7 @@ def _fetch_places(lat: float, lng: float, radius: int, category: str, limit: int
                     WHERE ST_DWithin(
                         ST_SetSRID(ST_MakePoint(%s, %s), 4326)::geography,
                         ST_SetSRID(
-                            ST_MakePoint(COALESCE(cc.center_lng, %s), COALESCE(cc.center_lat, %s)),
+                            ST_MakePoint(COALESCE(ne.lng, cc.center_lng, %s), COALESCE(ne.lat, cc.center_lat, %s)),
                             4326
                         )::geography,
                         %s

--- a/src/frontend/web/routes/ios_api.py
+++ b/src/frontend/web/routes/ios_api.py
@@ -263,7 +263,7 @@ def _fetch_weather_from_db(lat: float, lng: float) -> tuple[dict, int] | None:
             with conn.cursor(cursor_factory=psycopg2.extras.DictCursor) as cur:
                 cur.execute(
                     """
-                    SELECT temperature, precipitation_type, pm10, pm25
+                    SELECT temperature, precipitation_type, pm10, pm25, outdoor_status
                     FROM locallink.realtime_weather_conditions
                     WHERE location = %s
                       AND record_time > NOW() - INTERVAL '70 minutes'
@@ -294,6 +294,7 @@ def _fetch_weather_from_db(lat: float, lng: float) -> tuple[dict, int] | None:
             "grade_ko": _DUST_GRADE_LABELS.get(grade, _DUST_GRADE_LABELS["unknown"]),
         },
         "forecast": [],
+        "outdoor_status": row["outdoor_status"] or "",
         "source": "db",
         "dust_source": "db",
         "location": location,
@@ -386,6 +387,13 @@ def _weather_snapshot(lat: float, lng: float) -> tuple[dict, int]:
         _db_result = _fetch_weather_from_db(lat, lng)
         if _db_result is not None:
             _db_payload, _db_status = _db_result
+            # Open-Meteo에서 예보 데이터 보충 (best-effort)
+            try:
+                _weather_future = _WEATHER_FETCH_EXECUTOR.submit(_fetch_open_meteo_weather, lat, lng)
+                _weather_data = _weather_future.result(timeout=_OPEN_METEO_TIMEOUT_SEC + 0.5)
+                _db_payload["forecast"] = _build_weather_forecast_payload(_weather_data)
+            except Exception:
+                pass  # forecast stays []
             with _WEATHER_CACHE_LOCK:
                 _store_cached_weather_entry(key, _db_payload, _db_status)
                 _current_inflight = _WEATHER_INFLIGHT.pop(key, None)
@@ -446,11 +454,14 @@ def _compute_weather_snapshot(lat: float, lng: float) -> tuple[dict, int]:
         except Exception:
             dust_source = "unavailable"
 
+        outdoor_status = _compute_outdoor_status(current.get("weather_code"), dust["grade"])
+
         return {
             "temp": temp,
             "icon": icon,
             "dust": dust,
             "forecast": forecast,
+            "outdoor_status": outdoor_status,
             "source": "open-meteo",
             "dust_source": dust_source,
         }, 200
@@ -546,6 +557,20 @@ def _legacy_weather_snapshot(lat: float, lng: float) -> tuple[dict, int]:
         return {"temp": str(temp), "icon": icon}, 200
     except Exception as exc:
         return {"error": str(exc)}, 500
+
+
+def _compute_outdoor_status(weather_code_value, dust_grade: str) -> str:
+    """날씨 코드와 미세먼지 등급을 기반으로 outdoor_status 텍스트를 생성."""
+    code = _safe_float(weather_code_value)
+    if code is not None:
+        c = int(round(code))
+        if c in {51, 53, 55, 56, 57, 61, 63, 65, 66, 67, 71, 73, 75, 77, 80, 81, 82, 85, 86, 95, 96, 99}:
+            return "비/눈"
+    if dust_grade in {"bad", "very_bad"}:
+        return "미세먼지 나쁨"
+    if code is not None and int(round(code)) in {0, 1, 2} and dust_grade in {"good", "normal", "unknown"}:
+        return "야외활동 쾌적"
+    return "보통"
 
 
 def _safe_float(value) -> float | None:

--- a/src/frontend/web/routes/ios_api.py
+++ b/src/frontend/web/routes/ios_api.py
@@ -387,13 +387,24 @@ def _weather_snapshot(lat: float, lng: float) -> tuple[dict, int]:
         _db_result = _fetch_weather_from_db(lat, lng)
         if _db_result is not None:
             _db_payload, _db_status = _db_result
-            # Open-Meteo에서 예보 데이터 보충 (best-effort)
+            # Open-Meteo에서 예보 + 누락된 온도 보충 (best-effort)
             try:
                 _weather_future = _WEATHER_FETCH_EXECUTOR.submit(_fetch_open_meteo_weather, lat, lng)
                 _weather_data = _weather_future.result(timeout=_OPEN_METEO_TIMEOUT_SEC + 0.5)
                 _db_payload["forecast"] = _build_weather_forecast_payload(_weather_data)
+                # DB 온도가 NULL인 경우 Open-Meteo 현재 온도로 보충
+                if _db_payload.get("temp") == "--":
+                    _om_current = _weather_data.get("current") or {}
+                    _om_temp = _format_temp_value(_om_current.get("temperature_2m"))
+                    if _om_temp != "--":
+                        _db_payload["temp"] = _om_temp
+                        _db_payload["icon"] = _wmo_weather_icon(_om_current.get("weather_code"))
+                        _db_payload["outdoor_status"] = _compute_outdoor_status(
+                            _om_current.get("weather_code"),
+                            (_db_payload.get("dust") or {}).get("grade", "unknown"),
+                        )
             except Exception:
-                pass  # forecast stays []
+                pass  # forecast stays [], temp stays "--"
             with _WEATHER_CACHE_LOCK:
                 _store_cached_weather_entry(key, _db_payload, _db_status)
                 _current_inflight = _WEATHER_INFLIGHT.pop(key, None)

--- a/src/frontend/web/routes/ios_api.py
+++ b/src/frontend/web/routes/ios_api.py
@@ -33,7 +33,7 @@ ios_api_bp = Blueprint("ios_api", __name__)
 
 _DEFAULT_LAT = 37.2636
 _DEFAULT_LNG = 127.0286
-_DEFAULT_RADIUS = 3000
+_DEFAULT_RADIUS = 10000
 _DEFAULT_LIMIT = 50
 _MAX_LIMIT = 100
 

--- a/src/frontend/web/routes/ios_api.py
+++ b/src/frontend/web/routes/ios_api.py
@@ -1005,7 +1005,7 @@ def _fetch_places_by_city(
                         SELECT
                             MD5(COALESCE(title, '') || '|' || COALESCE(url, '') || '|' || COALESCE(city, '')) AS id,
                             COALESCE(title, '') AS name,
-                            COALESCE(NULLIF(TRIM(title_en), ''), COALESCE(title, '')) AS name_en,
+                            COALESCE(title, '') AS name_en,
                             COALESCE(inst_nm, '') AS address,
                             COALESCE(inst_nm, '') AS address_en,
                             COALESCE(city, '') AS region,
@@ -1050,12 +1050,14 @@ def _fetch_places_by_city(
                         TRUE AS is_approximate_location,
                         ne.event_start_date::TEXT AS event_start_date,
                         ne.event_end_date::TEXT AS event_end_date,
-                        ne.event_url
+                        ne.event_url,
+                        (ne.event_end_date IS NULL OR ne.event_end_date >= CURRENT_DATE) AS is_ongoing
                     FROM normalized_events ne
                     LEFT JOIN city_centers cc
                       ON REPLACE(COALESCE(TRIM(cc.city_name), ''), ' ', '') = REPLACE(COALESCE(TRIM(ne.region), ''), ' ', '')
-                    WHERE (ne.event_end_date IS NULL OR ne.event_end_date >= CURRENT_DATE)
-                    ORDER BY distance_m, ne.event_start_date NULLS LAST
+                    ORDER BY
+                        CASE WHEN (ne.event_end_date IS NULL OR ne.event_end_date >= CURRENT_DATE) THEN 0 ELSE 1 END,
+                        distance_m, ne.event_start_date NULLS LAST
                     LIMIT %s
                     """,
                     (
@@ -1260,7 +1262,7 @@ def _fetch_places(lat: float, lng: float, radius: int, category: str, limit: int
                         SELECT
                             MD5(COALESCE(title, '') || '|' || COALESCE(url, '') || '|' || COALESCE(city, '')) AS id,
                             COALESCE(title, '') AS name,
-                            COALESCE(NULLIF(TRIM(title_en), ''), COALESCE(title, '')) AS name_en,
+                            COALESCE(title, '') AS name_en,
                             COALESCE(inst_nm, '') AS address,
                             COALESCE(inst_nm, '') AS address_en,
                             COALESCE(city, '') AS region,
@@ -1304,12 +1306,12 @@ def _fetch_places(lat: float, lng: float, radius: int, category: str, limit: int
                         TRUE AS is_approximate_location,
                         ne.event_start_date::TEXT AS event_start_date,
                         ne.event_end_date::TEXT AS event_end_date,
-                        ne.event_url
+                        ne.event_url,
+                        (ne.event_end_date IS NULL OR ne.event_end_date >= CURRENT_DATE) AS is_ongoing
                     FROM normalized_events ne
                     LEFT JOIN city_centers cc
                       ON cc.city_name = ne.region
-                    WHERE (ne.event_end_date IS NULL OR ne.event_end_date >= CURRENT_DATE)
-                      AND ST_DWithin(
+                    WHERE ST_DWithin(
                         ST_SetSRID(ST_MakePoint(%s, %s), 4326)::geography,
                         ST_SetSRID(
                             ST_MakePoint(COALESCE(cc.center_lng, %s), COALESCE(cc.center_lat, %s)),
@@ -1317,7 +1319,7 @@ def _fetch_places(lat: float, lng: float, radius: int, category: str, limit: int
                         )::geography,
                         %s
                       )
-                    ORDER BY distance_m
+                    ORDER BY CASE WHEN (ne.event_end_date IS NULL OR ne.event_end_date >= CURRENT_DATE) THEN 0 ELSE 1 END, distance_m
                     LIMIT %s
                     """,
                     (

--- a/src/frontend/web/routes/ios_api.py
+++ b/src/frontend/web/routes/ios_api.py
@@ -1075,7 +1075,11 @@ def _fetch_places_by_city(
                 )
                 results.extend(_normalize_place_row(dict(row)) for row in cursor.fetchall())
 
-    results.sort(key=lambda row: row.get("distance_m") or 0)
+    def _sort_key(row):
+        is_ongoing_event = row.get("category") == "event" and row.get("is_ongoing") is True
+        return (0 if is_ongoing_event else 1, row.get("distance_m") or 0)
+
+    results.sort(key=_sort_key)
     if category == "all":
         return results
     return results[: max(limit, 1)]
@@ -1343,7 +1347,11 @@ def _fetch_places(lat: float, lng: float, radius: int, category: str, limit: int
                 )
                 results.extend(_normalize_place_row(dict(row)) for row in cursor.fetchall())
 
-    results.sort(key=lambda row: row.get("distance_m") or 0)
+    def _sort_key(row):
+        is_ongoing_event = row.get("category") == "event" and row.get("is_ongoing") is True
+        return (0 if is_ongoing_event else 1, row.get("distance_m") or 0)
+
+    results.sort(key=_sort_key)
     if category == "all":
         return results
     return results[: max(limit, 1)]

--- a/src/frontend/web/routes/planner.py
+++ b/src/frontend/web/routes/planner.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from flask import Blueprint, jsonify, request
+
+from src.frontend.web.services.planner_service import (
+    create_daily_plan_payload,
+    create_intervention_payload,
+)
+
+planner_bp = Blueprint("planner", __name__)
+
+
+@planner_bp.route("/api/planner/daily-plan", methods=["POST"])
+def daily_plan():
+    body = request.get_json(silent=True) or {}
+    try:
+        lat = float(body.get("lat", 37.2636))
+        lng = float(body.get("lng", 127.0286))
+        language = str(body.get("language", "Korean")).strip()
+    except (TypeError, ValueError):
+        return jsonify({"error": "invalid parameters"}), 400
+
+    payload, status = create_daily_plan_payload(lat, lng, language=language)
+    return jsonify(payload), status
+
+
+@planner_bp.route("/api/planner/intervention", methods=["GET"])
+def intervention():
+    try:
+        lat = float(request.args.get("lat", 37.2636))
+        lng = float(request.args.get("lng", 127.0286))
+        radius = int(request.args.get("radius", 10000))
+    except (TypeError, ValueError):
+        return jsonify({"error": "invalid parameters"}), 400
+
+    payload, status = create_intervention_payload(lat, lng, radius_m=radius)
+    return jsonify(payload), status

--- a/src/frontend/web/services/map_api_service.py
+++ b/src/frontend/web/services/map_api_service.py
@@ -8,7 +8,7 @@ from src.frontend.web.services.db import get_db_connection
 
 DEFAULT_LAT = 37.2636
 DEFAULT_LNG = 127.0286
-DEFAULT_RADIUS = 3000
+DEFAULT_RADIUS = 10000
 DEFAULT_LIMIT = 50
 MAX_LIMIT = 100
 

--- a/src/frontend/web/services/planner_service.py
+++ b/src/frontend/web/services/planner_service.py
@@ -34,7 +34,7 @@ def create_daily_plan_payload(
     lat: float,
     lng: float,
     language: str = "English",
-    timeout_sec: int = 30,
+    timeout_sec: int = 90,
 ) -> tuple[dict[str, Any], int]:
     """
     DailyTravelPlanner.create_daily_plan()을 최대 timeout_sec 초 안에 실행한다.

--- a/src/frontend/web/services/planner_service.py
+++ b/src/frontend/web/services/planner_service.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import concurrent.futures
+from typing import Any
+
+# ── 모듈 레벨 싱글턴 (last_weather_state 유지 필수) ──────────────────────
+_intervention_manager: "_WeatherInterventionManager | None" = None
+
+
+def _get_intervention_manager(lat: float, lng: float) -> "_WeatherInterventionManager":
+    """같은 위치라면 인스턴스를 재사용해 last_weather_state를 보존한다."""
+    global _intervention_manager
+    if _intervention_manager is None:
+        _intervention_manager = _WeatherInterventionManager(lat, lng)
+    return _intervention_manager
+
+
+class _WeatherInterventionManager:
+    def __init__(self, lat: float, lng: float) -> None:
+        from src.services.weather_planner import WeatherTravelPlanner
+        self._planner = WeatherTravelPlanner(lat, lng)
+
+    def get_intervention(self, lat: float, lng: float, radius_m: int = 10000):
+        """날씨 변화가 감지되면 (places, type)를 반환, 없으면 None."""
+        # 좌표가 크게 변하면 동일 planner 재사용 (last_weather_state 유지)
+        self._planner.lat = lat
+        self._planner.lng = lng
+        return self._planner.check_and_propose_intervention(radius_m=radius_m)
+
+
+# ── 하루 일정 ─────────────────────────────────────────────────────────────
+
+def create_daily_plan_payload(
+    lat: float,
+    lng: float,
+    language: str = "English",
+    timeout_sec: int = 30,
+) -> tuple[dict[str, Any], int]:
+    """
+    DailyTravelPlanner.create_daily_plan()을 최대 timeout_sec 초 안에 실행한다.
+    도슨트 없는 슬롯은 script="" 로 허용한다.
+    """
+    def _run():
+        from src.services.daily_planner import DailyTravelPlanner
+        planner = DailyTravelPlanner(lat, lng)
+        return planner.create_daily_plan(language=language)
+
+    try:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+            future = executor.submit(_run)
+            result = future.result(timeout=timeout_sec)
+    except concurrent.futures.TimeoutError:
+        return {"error": "planner timed out"}, 504
+    except Exception as exc:
+        return {"error": str(exc)}, 500
+
+    if "error" in result:
+        return {"error": result["error"]}, 500
+
+    # plan 항목 정규화: script 키 누락 방지
+    for item in result.get("plan", []):
+        item.setdefault("script", "")
+        place = item.get("place") or {}
+        item["place"] = {
+            "name": place.get("name") or place.get("tourist_nm", ""),
+            "lat": place.get("lat"),
+            "lng": place.get("lng"),
+            "road_addr": place.get("road_addr", ""),
+            "source_type": place.get("source_type", "attraction"),
+            "itinerary_role": place.get("itinerary_role", ""),
+        }
+
+    return result, 200
+
+
+# ── 날씨 개입 개요 ──────────────────────────────────────────────────────────
+
+def create_intervention_payload(
+    lat: float,
+    lng: float,
+    radius_m: int = 10000,
+) -> tuple[dict[str, Any], int]:
+    try:
+        manager = _get_intervention_manager(lat, lng)
+        result = manager.get_intervention(lat, lng, radius_m=radius_m)
+    except Exception as exc:
+        return {"error": str(exc)}, 500
+
+    if result is None:
+        return {"intervention": None}, 200
+
+    places, alert_type = result
+    serialized = []
+    for p in places:
+        serialized.append({
+            "name": p.get("name", ""),
+            "lat": p.get("lat"),
+            "lng": p.get("lng"),
+            "dist": p.get("dist"),
+            "road_addr": p.get("road_addr", ""),
+            "source_type": p.get("source_type", "attraction"),
+        })
+
+    return {"intervention": {"type": alert_type, "places": serialized}}, 200

--- a/src/frontend/web/static/css/layout.css
+++ b/src/frontend/web/static/css/layout.css
@@ -226,7 +226,7 @@ body {
   position: absolute;
   top: 12px;
   left: 10px;
-  right: 10px;
+  right: 110px;
   z-index: 30;
   display: flex;
   gap: 8px;
@@ -485,11 +485,23 @@ body {
   width: var(--map-top-stack-width);
   display: flex;
   justify-content: flex-end;
+  align-items: center;
+  gap: 8px;
   pointer-events: none;
 }
 
 .map-weather-row .map-weather-btn {
   pointer-events: auto;
+}
+
+.map-planner-btn {
+  position: absolute;
+  top: 12px;
+  right: 10px;
+  z-index: 31;
+  font-size: 0.8rem;
+  font-weight: 700;
+  white-space: nowrap;
 }
 
 .place-card {
@@ -835,3 +847,141 @@ body {
     padding: 18px;
   }
 }
+
+/* ── 하루 일정 플래너 시트 ─────────────────────────────────────────────── */
+
+.planner-sheet {
+  max-height: 80dvh;
+}
+
+.planner-sheet__header {
+  margin-bottom: 12px;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  gap: 6px;
+}
+
+.planner-refresh-btn {
+  margin-left: auto;
+  font-size: 0.76rem;
+  padding: 4px 10px;
+  opacity: 0.75;
+}
+
+.planner-weather-badge {
+  display: inline-block;
+  font-size: 0.78rem;
+  font-weight: 700;
+  color: #0f766e;
+  background: #f0fdf4;
+  border-radius: 20px;
+  padding: 2px 10px;
+  margin-top: -4px;
+}
+
+.planner-slots {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding-bottom: 8px;
+}
+
+.plan-slot-card {
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  padding: 12px 14px;
+  transition: background 0.15s;
+}
+
+.plan-slot-card:active {
+  background: #e2e8f0;
+}
+
+.plan-slot-card__period {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.82rem;
+  color: #64748b;
+  margin-bottom: 4px;
+}
+
+.plan-slot-card__time {
+  margin-left: auto;
+  font-size: 0.76rem;
+  color: #94a3b8;
+}
+
+.plan-slot-card__name {
+  font-size: 1rem;
+  font-weight: 800;
+  color: #1e293b;
+  margin-bottom: 2px;
+}
+
+.plan-slot-card__addr {
+  font-size: 0.76rem;
+  color: #94a3b8;
+  margin-bottom: 6px;
+}
+
+.plan-slot-card__script {
+  font-size: 0.82rem;
+  color: #475569;
+  line-height: 1.55;
+  margin: 0;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.planner-skeleton {
+  text-align: center;
+  padding: 32px 0;
+  color: #94a3b8;
+  font-size: 0.9rem;
+}
+
+.planner-error {
+  text-align: center;
+  padding: 24px 0;
+  color: #ef4444;
+  font-size: 0.88rem;
+}
+
+/* ── 날씨 개입 토스트 ──────────────────────────────────────────────────── */
+
+.intervention-toast {
+  position: fixed;
+  top: calc(60px + env(safe-area-inset-top));
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 200;
+  background: rgba(15, 23, 42, 0.9);
+  color: #fff;
+  border-radius: 24px;
+  padding: 10px 16px 10px 18px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 0.88rem;
+  font-weight: 600;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.28);
+  max-width: calc(100% - 32px);
+  white-space: nowrap;
+}
+
+.intervention-toast__close {
+  background: none;
+  border: none;
+  color: #cbd5e1;
+  font-size: 0.9rem;
+  cursor: pointer;
+  padding: 0 2px;
+  line-height: 1;
+  flex-shrink: 0;
+}
+

--- a/src/frontend/web/static/css/layout.css
+++ b/src/frontend/web/static/css/layout.css
@@ -575,6 +575,10 @@ body {
   color: var(--obang-east);
 }
 
+.place-card--expired {
+  opacity: 0.5;
+}
+
 .place-card__meta {
   font-size: 0.78rem;
   font-weight: 700;

--- a/src/frontend/web/static/css/layout.css
+++ b/src/frontend/web/static/css/layout.css
@@ -342,28 +342,58 @@ body {
   pointer-events: none;
 }
 
+/* [UX개선] 도슨트 자막 패널 — 배경 불투명화 + 좌측 강조 보더로 시선 유도 */
 .map-subtitle-panel {
   width: min(460px, calc(100vw - 24px));
-  background: rgba(255, 255, 255, 0.94);
+  background: rgba(255, 255, 255, 0.98);
   border-radius: 16px;
-  padding: 12px;
-  box-shadow: 0 8px 28px rgba(18, 31, 45, 0.16);
-  max-height: min(26dvh, 220px);
+  border-left: 4px solid var(--obang-east);
+  padding: 14px 14px 14px 16px;
+  box-shadow: 0 8px 32px rgba(18, 31, 45, 0.22);
+  pointer-events: auto;
+  transition: opacity 0.22s ease, visibility 0.22s;
+}
+
+/* 바텀시트가 열릴 때 자막 패널 숨기기 */
+.map-subtitle-panel.hidden {
+  opacity: 0;
+  pointer-events: none;
+  visibility: hidden;
+}
+
+/* [UX개선] 도슨트 자막 텍스트 — 5줄 초과 시 스크롤, 버튼은 항상 표시 */
+.map-subtitle-text {
+  font-size: 0.93rem;
+  line-height: 1.6;
+  color: #111827;
+  font-weight: 500;
+  max-height: calc(1.6em * 5);
   overflow-y: auto;
   overscroll-behavior: contain;
-  pointer-events: auto;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(100, 116, 139, 0.4) transparent;
+  padding-right: 4px;
+  margin: 0;
 }
 
-.map-subtitle-text {
-  font-size: 0.87rem;
-  line-height: 1.55;
-  color: #1f2937;
-}
-
+/* [UX개선] 자막 하단 CTA 영역 */
 .map-subtitle-actions {
-  margin-top: 10px;
+  margin-top: 12px;
   display: flex;
   gap: 8px;
+}
+
+/* [UX개선] "정보 더 듣기" Primary CTA — 어두운 배경+흰 글씨로 클릭 유도 강화 */
+#more-info-btn {
+  background: var(--obang-north);
+  color: #fff;
+  font-size: 0.82rem;
+  font-weight: 800;
+  border-radius: 10px;
+  padding: 10px 18px;
+  box-shadow: 0 4px 14px rgba(16, 24, 40, 0.3);
+  letter-spacing: 0.01em;
 }
 
 .map-fab-row {
@@ -377,15 +407,16 @@ body {
   justify-content: space-between;
 }
 
+/* [UX개선] FAB 버튼 — 흰 테두리 링 + 그림자 강화로 지도 위 인식률 향상 */
 .fab-circle {
-  width: 48px;
-  height: 48px;
-  border: 0;
+  width: 52px;
+  height: 52px;
+  border: 2.5px solid rgba(255, 255, 255, 0.9);
   border-radius: 50%;
   background: var(--obang-east);
   color: #fff;
-  font-size: 1.15rem;
-  box-shadow: 0 8px 24px rgba(16, 24, 40, 0.25);
+  font-size: 1.2rem;
+  box-shadow: 0 4px 8px rgba(0,0,0,0.18), 0 10px 28px rgba(16, 24, 40, 0.32);
   cursor: pointer;
 }
 
@@ -393,9 +424,10 @@ body {
   background: rgba(26, 32, 44, 0.84);
 }
 
+/* [UX개선] 자동 도슨트 FAB — 크기+강조 유지 */
 .fab-circle.auto {
-  width: 74px;
-  height: 74px;
+  width: 78px;
+  height: 78px;
   font-size: 0.88rem;
   font-weight: 800;
   display: flex;
@@ -403,25 +435,30 @@ body {
   justify-content: center;
   flex-direction: column;
   gap: 2px;
+  transition: background 0.25s ease, box-shadow 0.25s ease, transform 0.18s ease;
 }
 
 .fab-circle.auto.active {
   background: var(--obang-east);
+  box-shadow: 0 0 0 4px rgba(var(--obang-east-rgb, 59,130,246), 0.28),
+              0 6px 20px rgba(16, 24, 40, 0.38);
+  transform: scale(1.06);
 }
 
+/* [UX개선] 장소 카드가 시선을 독점하지 않도록 시각 무게 경량화 */
 .map-card-panel {
   width: var(--map-top-stack-width);
-  min-height: 146px;
-  max-height: 146px;
-  background: rgba(255, 255, 255, 0.98);
+  min-height: 130px;
+  max-height: 130px;
+  background: rgba(255, 255, 255, 0.92);
   border-radius: 20px;
-  box-shadow: 0 12px 26px rgba(18, 31, 45, 0.2);
-  padding: 10px 12px;
-  overflow-x: auto;
-  overflow-y: hidden;
+  box-shadow: 0 4px 12px rgba(18, 31, 45, 0.12);
+  padding: 8px 12px;
   display: flex;
   align-items: stretch;
   gap: 10px;
+  overflow-x: auto;
+  overflow-y: hidden;
   scroll-snap-type: x mandatory;
   overscroll-behavior-x: contain;
   overscroll-behavior-y: none;
@@ -429,6 +466,15 @@ body {
   -webkit-overflow-scrolling: touch;
   scrollbar-width: none;
   pointer-events: auto;
+  transition: opacity 0.22s ease, transform 0.22s ease, visibility 0.22s;  /* 숨김 애니메이션 */
+}
+
+/* [UX개선] 바텀시트가 열렸을 때 카드 패널 숨기기 (Google Maps 방식) */
+.map-card-panel.hidden {
+  opacity: 0;
+  transform: translateY(-12px);
+  pointer-events: none;
+  visibility: hidden;
 }
 
 .map-card-panel::-webkit-scrollbar {
@@ -549,12 +595,18 @@ body {
   flex-shrink: 0;
 }
 
+/* [UX개선] 이미지 로드 실패 시 빈 블록 제거 */
 .detail-sheet__image {
   width: 100%;
   height: 170px;
   border-radius: 14px;
   background: linear-gradient(135deg, rgba(245, 200, 66, 0.4), rgba(43, 108, 176, 0.5));
   object-fit: cover;
+  display: block;
+}
+
+.detail-sheet__image[data-broken] {
+  display: none !important;
 }
 
 .sheet-backdrop {

--- a/src/frontend/web/static/css/layout.css
+++ b/src/frontend/web/static/css/layout.css
@@ -658,30 +658,50 @@ body {
   color: #1f2937;
 }
 
-.forecast-list {
+.forecast-chart-wrap {
+  overflow-x: auto;
+  overflow-y: hidden;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: none;
+  margin: 12px -16px 0;
+  padding: 0 16px;
+}
+.forecast-chart-wrap::-webkit-scrollbar {
+  display: none;
+}
+.forecast-chart-inner {
+  position: relative;
+}
+.forecast-svg {
+  display: block;
+}
+.forecast-temp-lbl {
+  font-size: 11px;
+  font-weight: 700;
+  fill: #374151;
+}
+.forecast-icon-row,
+.forecast-time-row {
   display: flex;
-  flex-direction: column;
-  gap: 8px;
-  margin-top: 8px;
 }
-
-.forecast-item {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) 28px auto;
-  align-items: center;
-  column-gap: 10px;
-  background: #f8fafc;
-  border-radius: 10px;
-  padding: 9px 10px;
-  font-size: 0.82rem;
+.forecast-icon-cell {
+  flex: 0 0 56px;
+  text-align: center;
+  font-size: 1.3rem;
+  line-height: 1;
+  padding: 4px 0;
 }
-
-.forecast-item span:first-child {
-  min-width: 0;
+.forecast-time-cell {
+  flex: 0 0 56px;
+  text-align: center;
+  font-size: 0.7rem;
+  color: #9ca3af;
+  padding-bottom: 4px;
 }
-
-.forecast-item strong {
-  justify-self: end;
+.forecast-empty {
+  color: #9ca3af;
+  font-size: 0.85rem;
+  padding: 16px 0;
 }
 
 .location-overlay {

--- a/src/frontend/web/static/js/map_logic.js
+++ b/src/frontend/web/static/js/map_logic.js
@@ -232,7 +232,7 @@
     places.forEach((place) => {
       const marker = new kakao.maps.Marker({
         position: new kakao.maps.LatLng(place.lat, place.lng),
-        image: makePinSvg(categoryColor(place.category), false),
+        image: makePinSvg((place.category === 'event' && place.is_ongoing === false) ? '#9ca3af' : categoryColor(place.category), false),
         map: APP.map
       });
       kakao.maps.event.addListener(marker, 'click', () => {
@@ -245,15 +245,16 @@
   function syncMarkerState() {
     APP.markers.forEach((item) => {
       const active = APP.selectedPlace && APP.selectedPlace.id === item.placeId;
-      item.marker.setImage(makePinSvg(categoryColor(item.place.category), active));
+      item.marker.setImage(makePinSvg((item.place.category === 'event' && item.place.is_ongoing === false) ? '#9ca3af' : categoryColor(item.place.category), active));
     });
   }
 
   function buildCard(place) {
     const active = APP.selectedPlace && APP.selectedPlace.id === place.id;
+    const isExpiredEvent = place.category === 'event' && place.is_ongoing === false;
     const wrapper = document.createElement('button');
     wrapper.type = 'button';
-    wrapper.className = 'place-card' + (active ? ' active' : '');
+    wrapper.className = 'place-card' + (active ? ' active' : '') + (isExpiredEvent ? ' place-card--expired' : '');
     wrapper.dataset.placeId = place.id;
 
     const image = place.image_url
@@ -265,12 +266,16 @@
     const metaParts = [];
     if (region) metaParts.push(`<span>${escapeHtml(region)}</span>`);
     if (distance) metaParts.push(`<span>${escapeHtml(distance)}</span>`);
+    let categoryLabel = placeCategoryLabel(place);
+    if (place.category === 'event') {
+      categoryLabel += isExpiredEvent ? ' · 종료됨' : ' · 진행중';
+    }
 
     wrapper.innerHTML = `
       <div class="place-card__copy">
         <div class="place-card__name">${escapeHtml(placeName(place))}</div>
         <div class="place-card__category place-card__category--${escapeHtml(category)}">
-          ${escapeHtml(placeCategoryLabel(place))}
+          ${escapeHtml(categoryLabel)}
         </div>
         <div class="place-card__meta">${metaParts.join('')}</div>
       </div>
@@ -436,16 +441,28 @@
     document.getElementById('detail-recommend').textContent = recommendationText(place);
 
     const eventInfoEl = document.getElementById('detail-event-info');
-    const hasEvent = !!(place.event_start_date || place.event_end_date);
+    const hasEvent = place.category === 'event';
     eventInfoEl.style.display = hasEvent ? 'block' : 'none';
     if (hasEvent) {
-      const start = _fmtEventDate(place.event_start_date);
-      const end   = _fmtEventDate(place.event_end_date);
-      let dateText = '🗓️';
-      if (start && end)  dateText += ` ${start} ~ ${end}`;
-      else if (start)    dateText += ` ${start}부터`;
-      else if (end)      dateText += ` ~${end}까지`;
-      document.getElementById('detail-event-dates').textContent = dateText;
+      const isOngoing = place.is_ongoing !== false;
+      const statusEl = document.getElementById('detail-event-status');
+      statusEl.textContent = isOngoing ? '🟢 진행 중' : '⛔ 종료된 행사';
+      statusEl.style.color = isOngoing ? '#2B6CB0' : '#9ca3af';
+
+      const hasDates = !!(place.event_start_date || place.event_end_date);
+      const datesEl = document.getElementById('detail-event-dates');
+      if (hasDates) {
+        const start = _fmtEventDate(place.event_start_date);
+        const end   = _fmtEventDate(place.event_end_date);
+        let dateText = '🗓️';
+        if (start && end)  dateText += ` ${start} ~ ${end}`;
+        else if (start)    dateText += ` ${start}부터`;
+        else if (end)      dateText += ` ~${end}까지`;
+        datesEl.textContent = dateText;
+        datesEl.style.display = 'block';
+      } else {
+        datesEl.style.display = 'none';
+      }
       const linkEl = document.getElementById('detail-event-link');
       if (place.event_url) {
         linkEl.href = place.event_url;

--- a/src/frontend/web/static/js/map_logic.js
+++ b/src/frontend/web/static/js/map_logic.js
@@ -415,6 +415,13 @@
     if (subtitlePanel) subtitlePanel.classList.remove('hidden');
   }
 
+  function _fmtEventDate(dateStr) {
+    if (!dateStr) return '';
+    const m = dateStr.match(/^(\d{4})-(\d{2})-(\d{2})/);
+    if (!m) return dateStr;
+    return `${m[1]}년 ${m[2]}월 ${m[3]}일`;
+  }
+
   function renderDetailSheet(place) {
     document.getElementById('detail-title').textContent = placeName(place);
     const sub = [place.category || '', placeRegion(place), placeDistance(place)].filter(Boolean).join(' · ');
@@ -427,6 +434,28 @@
       detailImage.style.display = 'none';
     }
     document.getElementById('detail-recommend').textContent = recommendationText(place);
+
+    const eventInfoEl = document.getElementById('detail-event-info');
+    const hasEvent = !!(place.event_start_date || place.event_end_date);
+    eventInfoEl.style.display = hasEvent ? 'block' : 'none';
+    if (hasEvent) {
+      const start = _fmtEventDate(place.event_start_date);
+      const end   = _fmtEventDate(place.event_end_date);
+      let dateText = '🗓️';
+      if (start && end)  dateText += ` ${start} ~ ${end}`;
+      else if (start)    dateText += ` ${start}부터`;
+      else if (end)      dateText += ` ~${end}까지`;
+      document.getElementById('detail-event-dates').textContent = dateText;
+      const linkEl = document.getElementById('detail-event-link');
+      if (place.event_url) {
+        linkEl.href = place.event_url;
+        linkEl.style.display = 'block';
+      } else {
+        linkEl.style.display = 'none';
+      }
+      const approxEl = document.getElementById('detail-event-approx');
+      approxEl.style.display = place.is_approximate_location ? 'block' : 'none';
+    }
 
     const moreBtn = document.getElementById('detail-more-btn');
     const canMore = !APP.hasPlayedDetailForPlace.has(place.id);

--- a/src/frontend/web/static/js/map_logic.js
+++ b/src/frontend/web/static/js/map_logic.js
@@ -37,7 +37,8 @@
     lastWeatherPosition: null,
     currentAudio: null,
     watchId: null,
-    hasPlayedDetailForPlace: new Set()
+    hasPlayedDetailForPlace: new Set(),
+    dailyPlan: null
   };
 
   function guardRoute() {
@@ -348,8 +349,8 @@
     const isNormal = !dust || dust.grade === 'normal' || dust.grade === 'good';
     if (isNormal) return `${label} ${grade}`;
     const metrics = [];
-    if (dust && dust.pm10 != null) metrics.push(`PM10 ${dust.pm10}`);
-    if (dust && dust.pm25 != null) metrics.push(`PM2.5 ${dust.pm25}`);
+    if (dust.pm10 != null) metrics.push(`PM10 ${dust.pm10}`);
+    if (dust.pm25 != null) metrics.push(`PM2.5 ${dust.pm25}`);
     if (!metrics.length) {
       return `${label} ${grade}`;
     }
@@ -737,6 +738,8 @@
         APP.lastWeatherKey = key;
         APP.lastWeatherPosition = currentWeatherPosition();
         renderWeatherSummary(payload);
+        // 날씨 갱신 직후 개입 알림 체크
+        checkIntervention(APP.userPosition.lat, APP.userPosition.lng);
         return payload;
       } catch (_error) {
         return APP.weather;
@@ -881,6 +884,26 @@
         loadPlaces();
       });
     });
+
+    document.getElementById('planner-btn').addEventListener('click', () => {
+      if (APP.dailyPlan) {
+        // 기존 계획 있으면 바로 시트를 열고, 재생성 여부를 확인
+        openSheet('planner-sheet');
+        renderPlannerSheet(APP.dailyPlan);
+        // 헤더에 재생성 버튼 표시
+        _showPlannerRefreshBtn();
+        return;
+      }
+      const center = APP.map ? APP.map.getCenter() : null;
+      const lat = center ? center.getLat() : APP.userPosition?.lat;
+      const lng = center ? center.getLng() : APP.userPosition?.lng;
+      if (!lat || !lng) return;
+      fetchDailyPlan(lat, lng);
+    });
+
+    document.getElementById('intervention-toast-close').addEventListener('click', () => {
+      document.getElementById('intervention-toast').style.display = 'none';
+    });
   }
 
   function startGeolocationWatch() {
@@ -905,6 +928,123 @@
       },
       { enableHighAccuracy: false, timeout: 10000, maximumAge: 120000 }
     );
+  }
+
+  // ── 하루 일정 플래너 ────────────────────────────────────────────────────
+
+  const PERIOD_ICON = { '오전': '🌅', '오후': '☀️', '저녁': '🌙' };
+  const ALERT_LABEL = {
+    rain_alert: '☔ 비가 옵니다 — 실내 장소를 추천해요',
+    pm_alert: '😷 미세먼지가 나빠요 — 실내 장소를 추천해요',
+    clear_sky_alert: '☀️ 날씨가 맑아요! 야외 활동하기 좋아요',
+  };
+
+  async function fetchDailyPlan(lat, lng) {
+    openSheet('planner-sheet');
+    const slotsEl = document.getElementById('planner-slots');
+    slotsEl.innerHTML = '<div class="planner-skeleton">일정을 불러오는 중…</div>';
+    document.getElementById('planner-location').textContent = '';
+    document.getElementById('planner-weather').textContent = '';
+
+    try {
+      const res = await fetch('/api/planner/daily-plan', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ lat, lng, language: APP.selectedLanguage || 'Korean' }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || 'planner error');
+      APP.dailyPlan = data;
+      renderPlannerSheet(data);
+      _showPlannerRefreshBtn();
+    } catch (err) {
+      slotsEl.innerHTML = `<p class="planner-error">일정을 가져오지 못했어요. 다시 시도해주세요.</p>`;
+    }
+  }
+
+  function _showPlannerRefreshBtn() {
+    const header = document.querySelector('#planner-sheet .planner-sheet__header');
+    if (!header) return;
+    let btn = header.querySelector('.planner-refresh-btn');
+    if (!btn) {
+      btn = document.createElement('button');
+      btn.className = 'map-pill-btn planner-refresh-btn';
+      btn.textContent = '🔄 일정 재생성';
+      btn.addEventListener('click', () => {
+        if (!confirm('하루 일정을 다시 생성할까요?\n현재 지도의 위치를 기준으로 새 일정이 만들어집니다.')) return;
+        APP.dailyPlan = null;
+        const center = APP.map ? APP.map.getCenter() : null;
+        const lat = center ? center.getLat() : APP.userPosition?.lat;
+        const lng = center ? center.getLng() : APP.userPosition?.lng;
+        if (!lat || !lng) return;
+        fetchDailyPlan(lat, lng);
+      });
+      header.appendChild(btn);
+    }
+  }
+
+  function renderPlannerSheet(data) {
+    document.getElementById('planner-location').textContent = data.location || '';
+    const w = data.weather || {};
+    const badge = [w.outdoor_status, w.temperature ? `${w.temperature}°C` : null]
+      .filter(Boolean).join('  ');
+    document.getElementById('planner-weather').textContent = badge;
+
+    const slotsEl = document.getElementById('planner-slots');
+    slotsEl.innerHTML = '';
+
+    const plan = data.plan || [];
+    if (!plan.length) {
+      slotsEl.innerHTML = '<p class="planner-error">추천 장소가 없어요.</p>';
+      return;
+    }
+
+    plan.forEach((item) => {
+      const icon = PERIOD_ICON[item.period] || '📍';
+      const place = item.place || {};
+      const card = document.createElement('div');
+      card.className = 'plan-slot-card';
+      card.innerHTML = `
+        <div class="plan-slot-card__period">${icon} <strong>${escapeHtml(item.period)}</strong><span class="plan-slot-card__time">${escapeHtml(item.time || '')}</span></div>
+        <div class="plan-slot-card__name">${escapeHtml(place.name || '')}</div>
+        ${place.road_addr ? `<div class="plan-slot-card__addr">${escapeHtml(place.road_addr)}</div>` : ''}
+        ${item.script ? `<p class="plan-slot-card__script">${escapeHtml(item.script)}</p>` : ''}
+      `;
+      // 지도 이동
+      if (place.lat && place.lng) {
+        card.addEventListener('click', () => {
+          closeSheets();
+          if (APP.map) {
+            APP.map.setCenter(new kakao.maps.LatLng(place.lat, place.lng));
+            APP.map.setLevel(4);
+          }
+        });
+        card.style.cursor = 'pointer';
+      }
+      slotsEl.appendChild(card);
+    });
+  }
+
+  // ── 날씨 개입 알림 ────────────────────────────────────────────────────────
+
+  async function checkIntervention(lat, lng) {
+    try {
+      const res = await fetch(`/api/planner/intervention?lat=${lat}&lng=${lng}`);
+      const data = await res.json();
+      if (!res.ok || !data.intervention) return;
+      showInterventionToast(data.intervention);
+    } catch (_) {
+      // 개입 알림 실패는 무시
+    }
+  }
+
+  function showInterventionToast(intervention) {
+    const label = ALERT_LABEL[intervention.type] || '날씨가 바뀌었어요';
+    const toast = document.getElementById('intervention-toast');
+    document.getElementById('intervention-toast-text').textContent = label;
+    toast.style.display = 'flex';
+    // 8초 후 자동 닫기
+    setTimeout(() => { toast.style.display = 'none'; }, 8000);
   }
 
   function escapeHtml(value) {

--- a/src/frontend/web/static/js/map_logic.js
+++ b/src/frontend/web/static/js/map_logic.js
@@ -725,9 +725,9 @@
       const query = new URLSearchParams({
         lat: String(lat),
         lng: String(lng),
-        radius: '10000',
+        radius: '20000',
         category: APP.selectedCategory,
-        scope: 'city',
+        scope: 'radius',
         limit: '100'
       });
 

--- a/src/frontend/web/static/js/map_logic.js
+++ b/src/frontend/web/static/js/map_logic.js
@@ -393,9 +393,10 @@
   function renderWeatherSummary(payload) {
     APP.weather = payload;
     const tempText = payload && payload.temp != null && payload.temp !== '' ? payload.temp : '--';
+    const outdoorStatus = payload && payload.outdoor_status ? payload.outdoor_status : '';
+    const tempAndStatus = [outdoorStatus, `${tempText}°C`].filter(Boolean).join(' · ');
     document.getElementById('weather-icon').textContent = payload.icon || '🌡️';
-    document.getElementById('weather-temp').textContent = `${tempText}°C`;
-    document.getElementById('weather-dust').textContent = dustSummaryText(payload.dust);
+    document.getElementById('weather-temp').textContent = tempAndStatus;
   }
 
   function openSheet(id) {
@@ -488,17 +489,16 @@
   function renderWeatherSheet() {
     const wrap = document.getElementById('forecast-chart');
     const nowText = document.getElementById('weather-now');
-    const dustText = document.getElementById('weather-dust-detail');
 
     if (!APP.weather) {
       nowText.textContent = TEXT.weatherEmpty || '';
-      dustText.textContent = '';
       wrap.innerHTML = '';
       return;
     }
 
-    nowText.textContent = `${TEXT.weatherNow || ''} ${APP.weather.temp}°C`;
-    dustText.textContent = dustSummaryText(APP.weather.dust);
+    // 야외활동 상태 표시
+    const outdoorStatus = APP.weather && APP.weather.outdoor_status ? APP.weather.outdoor_status : '';
+    nowText.textContent = [TEXT.weatherNow || '', outdoorStatus, `${APP.weather.temp}°C`].filter(Boolean).join(' ');
 
     const list = Array.isArray(APP.weather.forecast) ? APP.weather.forecast : [];
     if (!list.length) {
@@ -780,11 +780,33 @@
         if (!response.ok) {
           return APP.weather;
         }
+
+        if (!payload.outdoor_status) {
+          try {
+            const res = await fetch(`/api/planner/intervention?lat=${APP.userPosition.lat}&lng=${APP.userPosition.lng}`);
+            const data = await res.json();
+            if (res.ok && data.intervention) {
+              const label = ALERT_LABEL[data.intervention.type];
+              if (label) {
+                let statusText = '';
+                if (label.includes('—')) {
+                  statusText = label.split('—')[1].trim();
+                } else if (label.includes('!')) {
+                  statusText = label.split('!')[1].trim();
+                }
+                if (statusText) {
+                  payload.outdoor_status = statusText;
+                }
+              }
+            }
+          } catch (_) { /* ignore intervention fetch error */ }
+        }
+
         APP.lastWeatherFetchAt = Date.now();
         APP.lastWeatherKey = key;
         APP.lastWeatherPosition = currentWeatherPosition();
         renderWeatherSummary(payload);
-        // 날씨 갱신 직후 개입 알림 체크
+        // 날씨 갱신 직후 개입 알림 체크 (토스트 전용)
         checkIntervention(APP.userPosition.lat, APP.userPosition.lng);
         return payload;
       } catch (_error) {

--- a/src/frontend/web/static/js/map_logic.js
+++ b/src/frontend/web/static/js/map_logic.js
@@ -256,7 +256,7 @@
     wrapper.dataset.placeId = place.id;
 
     const image = place.image_url
-      ? `<img class="place-card__thumb" src="${escapeHtml(place.image_url)}" alt="${escapeHtml(placeName(place))}" />`
+      ? `<img class="place-card__thumb" src="${escapeHtml(place.image_url)}" alt="${escapeHtml(placeName(place))}" onerror="this.style.display='none'" />`
       : `<div class="place-card__thumb" aria-hidden="true"></div>`;
     const distance = placeDistance(place);
     const region = placeRegion(place);
@@ -277,10 +277,8 @@
     `;
 
     wrapper.addEventListener('click', () => {
-      selectPlace(place, { from: 'card', openDetail: false });
-    });
-    wrapper.addEventListener('dblclick', () => {
-      selectPlace(place, { from: 'card', openDetail: true });
+      const alreadySelected = APP.selectedPlace && APP.selectedPlace.id === place.id;
+      selectPlace(place, { from: 'card', openDetail: !alreadySelected });
     });
     return wrapper;
   }
@@ -395,6 +393,11 @@
   function openSheet(id) {
     document.getElementById('sheet-backdrop').classList.add('active');
     document.getElementById(id).classList.add('active');
+    // [UX개선] 시트가 열리면 카드 패널 + 자막 패널 숨기기 (Google Maps 방식)
+    const cardPanel = document.getElementById('card-panel');
+    if (cardPanel) cardPanel.classList.add('hidden');
+    const subtitlePanel = document.getElementById('status-panel');
+    if (subtitlePanel) subtitlePanel.classList.add('hidden');
   }
 
   function closeSheets() {
@@ -402,6 +405,11 @@
     document.querySelectorAll('.bottom-sheet').forEach((sheet) => {
       sheet.classList.remove('active');
     });
+    // [UX개선] 시트가 닫히면 카드 패널 + 자막 패널 복원
+    const cardPanel = document.getElementById('card-panel');
+    if (cardPanel) cardPanel.classList.remove('hidden');
+    const subtitlePanel = document.getElementById('status-panel');
+    if (subtitlePanel) subtitlePanel.classList.remove('hidden');
   }
 
   function renderDetailSheet(place) {
@@ -474,9 +482,11 @@
   function setAutoButtonState() {
     const autoBtn = document.getElementById('auto-btn');
     const label = document.getElementById('auto-label');
+    const iconSpan = autoBtn.querySelector('span:first-child');
     autoBtn.classList.toggle('active', APP.isAutoDocentEnabled);
     autoBtn.classList.toggle('secondary', !APP.isAutoDocentEnabled);
     label.textContent = APP.isAutoDocentEnabled ? 'ON' : 'OFF';
+    if (iconSpan) iconSpan.textContent = APP.isAutoDocentEnabled ? '✨' : '⏸';
     S.setBool(S.keys.isAutoDocentEnabled, APP.isAutoDocentEnabled);
   }
 

--- a/src/frontend/web/static/js/map_logic.js
+++ b/src/frontend/web/static/js/map_logic.js
@@ -345,6 +345,8 @@
   function dustSummaryText(dust) {
     const label = APP.selectedLanguage === 'en' ? 'Fine Dust' : '미세먼지';
     const grade = dustGradeLabel(dust);
+    const isNormal = !dust || dust.grade === 'normal' || dust.grade === 'good';
+    if (isNormal) return `${label} ${grade}`;
     const metrics = [];
     if (dust && dust.pm10 != null) metrics.push(`PM10 ${dust.pm10}`);
     if (dust && dust.pm25 != null) metrics.push(`PM2.5 ${dust.pm25}`);
@@ -429,22 +431,22 @@
     const canMore = !APP.hasPlayedDetailForPlace.has(place.id);
     moreBtn.style.display = canMore ? 'inline-block' : 'none';
     moreBtn.onclick = () => {
-      requestDocent(place, 'detail');
       APP.hasPlayedDetailForPlace.add(place.id);
-      moreBtn.style.display = 'none';
+      closeSheets();
+      requestDocent(place, 'detail');
     };
     openSheet('detail-sheet');
   }
 
   function renderWeatherSheet() {
-    const panel = document.getElementById('forecast-list');
+    const wrap = document.getElementById('forecast-chart');
     const nowText = document.getElementById('weather-now');
     const dustText = document.getElementById('weather-dust-detail');
-    panel.innerHTML = '';
 
     if (!APP.weather) {
       nowText.textContent = TEXT.weatherEmpty || '';
       dustText.textContent = '';
+      wrap.innerHTML = '';
       return;
     }
 
@@ -453,23 +455,73 @@
 
     const list = Array.isArray(APP.weather.forecast) ? APP.weather.forecast : [];
     if (!list.length) {
-      const empty = document.createElement('div');
-      empty.className = 'forecast-item';
-      empty.textContent = TEXT.weatherEmpty || '';
-      panel.appendChild(empty);
+      wrap.innerHTML = `<p class="forecast-empty">${escapeHtml(TEXT.weatherEmpty || '')}</p>`;
       return;
     }
 
-    list.forEach((item) => {
-      const row = document.createElement('div');
-      row.className = 'forecast-item';
-      row.innerHTML = `
-        <span>${escapeHtml(formatForecastTime(item.time))}</span>
-        <span>${escapeHtml(item.icon || '')}</span>
-        <strong>${escapeHtml(item.temp || '--')}°C</strong>
-      `;
-      panel.appendChild(row);
+    const COL_W = 56;
+    const SVG_H = 88;
+    const PAD_TOP = 26;
+    const PAD_BOT = 18;
+    const DRAW_H = SVG_H - PAD_TOP - PAD_BOT;
+    const totalW = list.length * COL_W;
+
+    const parsedTemps = list.map(d => { const v = parseFloat(d.temp); return isNaN(v) ? null : v; });
+    const validTemps = parsedTemps.filter(v => v !== null);
+    const tMax = validTemps.length ? Math.max(...validTemps) : 1;
+    const tMin = validTemps.length ? Math.min(...validTemps) : 0;
+    const tRange = tMax - tMin || 1;
+
+    const pts = list.map((item, i) => {
+      const temp = parsedTemps[i];
+      const x = i * COL_W + COL_W / 2;
+      const y = temp !== null
+        ? PAD_TOP + ((tMax - temp) / tRange) * DRAW_H
+        : PAD_TOP + DRAW_H / 2;
+      return { x, y, temp };
     });
+
+    // Smooth cubic bezier curve
+    let pathD = `M ${pts[0].x.toFixed(1)} ${pts[0].y.toFixed(1)}`;
+    for (let i = 1; i < pts.length; i++) {
+      const mx = ((pts[i - 1].x + pts[i].x) / 2).toFixed(1);
+      pathD += ` C ${mx} ${pts[i - 1].y.toFixed(1)}, ${mx} ${pts[i].y.toFixed(1)}, ${pts[i].x.toFixed(1)} ${pts[i].y.toFixed(1)}`;
+    }
+
+    const svgContent = [
+      `<path d="${pathD}" fill="none" stroke="#c8c8cc" stroke-width="2.5" stroke-linecap="round"/>`,
+      ...pts.map(p => `<circle cx="${p.x.toFixed(1)}" cy="${p.y.toFixed(1)}" r="3.5" fill="#9ca3af"/>`),
+      ...pts.map((p, i) => {
+        const label = p.temp !== null ? `${Math.round(p.temp)}°` : '--';
+        return `<text x="${p.x.toFixed(1)}" y="${(p.y - 10).toFixed(1)}" text-anchor="middle" class="forecast-temp-lbl">${escapeHtml(label)}</text>`;
+      }),
+    ].join('');
+
+    const iconCells = list.map(item =>
+      `<div class="forecast-icon-cell">${escapeHtml(item.icon || '')}</div>`
+    ).join('');
+    const timeCells = list.map(item =>
+      `<div class="forecast-time-cell">${escapeHtml(_chartHourLabel(item.time))}</div>`
+    ).join('');
+
+    wrap.innerHTML = `
+      <div class="forecast-chart-inner" style="width:${totalW}px">
+        <svg class="forecast-svg" width="${totalW}" height="${SVG_H}" viewBox="0 0 ${totalW} ${SVG_H}">
+          ${svgContent}
+        </svg>
+        <div class="forecast-icon-row">${iconCells}</div>
+        <div class="forecast-time-row">${timeCells}</div>
+      </div>`;
+  }
+
+  function _chartHourLabel(value) {
+    const raw = String(value || '').trim();
+    if (!raw) return '';
+    const m = raw.match(/T(\d{2}):/);
+    if (m) return `${m[1]}시`;
+    const date = new Date(/[zZ+]/.test(raw) ? raw : raw + '+09:00');
+    if (isNaN(date.getTime())) return raw;
+    return `${String(date.getHours()).padStart(2, '0')}시`;
   }
 
   function setVoiceButtonState() {

--- a/src/frontend/web/static/js/map_logic.js
+++ b/src/frontend/web/static/js/map_logic.js
@@ -942,7 +942,7 @@
   async function fetchDailyPlan(lat, lng) {
     openSheet('planner-sheet');
     const slotsEl = document.getElementById('planner-slots');
-    slotsEl.innerHTML = '<div class="planner-skeleton">일정을 불러오는 중…</div>';
+    slotsEl.innerHTML = '<div class="planner-skeleton">일정을 생성하는 중…<br><small style="opacity:.6;font-size:.75rem">처음 방문하는 장소는 최대 30~60초 소요돼요</small></div>';
     document.getElementById('planner-location').textContent = '';
     document.getElementById('planner-weather').textContent = '';
 

--- a/src/frontend/web/templates/base.html
+++ b/src/frontend/web/templates/base.html
@@ -12,6 +12,8 @@
   <link rel="stylesheet" href="{{ url_for('static', filename='css/theme.css') }}" />
   <link rel="stylesheet" href="{{ url_for('static', filename='css/layout.css') }}" />
   {% block head %}{% endblock %}
+  <!-- Contentsquare Tracking -->
+  <script src="https://t.contentsquare.net/uxa/34e2b3fc07281.js" async></script>
 </head>
 <body>
   {% block nav %}

--- a/src/frontend/web/templates/base.html
+++ b/src/frontend/web/templates/base.html
@@ -12,8 +12,8 @@
   <link rel="stylesheet" href="{{ url_for('static', filename='css/theme.css') }}" />
   <link rel="stylesheet" href="{{ url_for('static', filename='css/layout.css') }}" />
   {% block head %}{% endblock %}
-  <!-- Contentsquare Tracking -->
-  <script src="https://t.contentsquare.net/uxa/34e2b3fc07281.js" async></script>
+  <!-- Contentsquare Tracking (analytics — collects only on https) -->
+  <script src="https://t.contentsquare.net/uxa/34e2b3fc07281.js" async crossorigin="anonymous"></script>
 </head>
 <body>
   {% block nav %}

--- a/src/frontend/web/templates/map/index.html
+++ b/src/frontend/web/templates/map/index.html
@@ -64,6 +64,13 @@
   <img id="detail-image" class="detail-sheet__image" alt="place"
        onerror="this.setAttribute('data-broken','1'); this.style.display='none';" />
   <p id="detail-recommend" class="info-body" style="margin-top:10px;"></p>
+  <div id="detail-event-info" style="display:none;">
+    <p id="detail-event-dates" class="sheet-sub" style="font-size:.82rem; margin-top:8px;"></p>
+    <a id="detail-event-link" href="#" target="_blank" rel="noopener noreferrer"
+       class="btn-primary"
+       style="display:block; text-align:center; margin-top:8px; text-decoration:none;">행사 상세 보기 →</a>
+    <p id="detail-event-approx" style="display:none; font-size:.75rem; color:#aaa; margin-top:6px;">📍 정확한 위치 정보가 없어 시 중심 위치로 표시돼요</p>
+  </div>
   <div class="btn-row">
     <button id="detail-more-btn" class="btn-primary" style="width:100%;">{{ t('map_more_info') }}</button>
   </div>

--- a/src/frontend/web/templates/map/index.html
+++ b/src/frontend/web/templates/map/index.html
@@ -65,7 +65,8 @@
        onerror="this.setAttribute('data-broken','1'); this.style.display='none';" />
   <p id="detail-recommend" class="info-body" style="margin-top:10px;"></p>
   <div id="detail-event-info" style="display:none;">
-    <p id="detail-event-dates" class="sheet-sub" style="font-size:.82rem; margin-top:8px;"></p>
+    <p id="detail-event-status" style="font-size:.8rem; font-weight:800; margin-top:8px;"></p>
+    <p id="detail-event-dates" class="sheet-sub" style="font-size:.82rem; margin-top:4px;"></p>
     <a id="detail-event-link" href="#" target="_blank" rel="noopener noreferrer"
        class="btn-primary"
        style="display:block; text-align:center; margin-top:8px; text-decoration:none;">행사 상세 보기 →</a>

--- a/src/frontend/web/templates/map/index.html
+++ b/src/frontend/web/templates/map/index.html
@@ -25,7 +25,6 @@
         <span id="weather-icon">🌡️</span>
         <span class="map-weather-copy">
           <span id="weather-temp">--°C</span>
-          <span id="weather-dust">미세먼지 --</span>
         </span>
       </button>
     </div>
@@ -89,7 +88,6 @@
 <section id="weather-sheet" class="bottom-sheet" aria-hidden="true">
   <h3 class="sheet-title">{{ t('map_weather_title') }}</h3>
   <p id="weather-now" class="sheet-sub"></p>
-  <p id="weather-dust-detail" class="sheet-sub weather-dust-line"></p>
   <div id="forecast-chart" class="forecast-chart-wrap"></div>
 </section>
 

--- a/src/frontend/web/templates/map/index.html
+++ b/src/frontend/web/templates/map/index.html
@@ -66,7 +66,7 @@
   <h3 class="sheet-title">{{ t('map_weather_title') }}</h3>
   <p id="weather-now" class="sheet-sub"></p>
   <p id="weather-dust-detail" class="sheet-sub weather-dust-line"></p>
-  <div id="forecast-list" class="forecast-list"></div>
+  <div id="forecast-chart" class="forecast-chart-wrap"></div>
 </section>
 
 <div id="location-overlay" class="location-overlay">

--- a/src/frontend/web/templates/map/index.html
+++ b/src/frontend/web/templates/map/index.html
@@ -54,7 +54,8 @@
 <section id="detail-sheet" class="bottom-sheet" aria-hidden="true">
   <h3 id="detail-title" class="sheet-title"></h3>
   <p id="detail-sub" class="sheet-sub"></p>
-  <img id="detail-image" class="detail-sheet__image" alt="place" />
+  <img id="detail-image" class="detail-sheet__image" alt="place"
+       onerror="this.setAttribute('data-broken','1'); this.style.display='none';" />
   <p id="detail-recommend" class="info-body" style="margin-top:10px;"></p>
   <div class="btn-row">
     <button id="detail-more-btn" class="btn-primary" style="width:100%;">{{ t('map_more_info') }}</button>

--- a/src/frontend/web/templates/map/index.html
+++ b/src/frontend/web/templates/map/index.html
@@ -16,6 +16,8 @@
     <button class="map-chip" data-category="event">{{ t('map_filter_event') }}</button>
   </div>
 
+  <button id="planner-btn" class="map-pill-btn map-planner-btn" aria-label="하루 일정">🗓️ 하루 일정</button>
+
   <div class="map-top-stack">
     <div id="card-panel" class="map-card-panel"></div>
     <div class="map-weather-row">
@@ -47,6 +49,11 @@
     </button>
     <button id="loc-btn" class="fab-circle" aria-label="{{ t('map_current_location') }}">◎</button>
   </div>
+
+  <div id="intervention-toast" class="intervention-toast" style="display:none;">
+    <span id="intervention-toast-text"></span>
+    <button id="intervention-toast-close" class="intervention-toast__close" aria-label="닫기">✕</button>
+  </div>
 </div>
 
 <div id="sheet-backdrop" class="sheet-backdrop"></div>
@@ -60,6 +67,15 @@
   <div class="btn-row">
     <button id="detail-more-btn" class="btn-primary" style="width:100%;">{{ t('map_more_info') }}</button>
   </div>
+</section>
+
+<section id="planner-sheet" class="bottom-sheet planner-sheet" aria-hidden="true">
+  <div class="planner-sheet__header">
+    <h3 class="sheet-title">🗓️ 하루 일정</h3>
+    <p id="planner-location" class="sheet-sub"></p>
+    <p id="planner-weather" class="planner-weather-badge"></p>
+  </div>
+  <div id="planner-slots" class="planner-slots"></div>
 </section>
 
 <section id="weather-sheet" class="bottom-sheet" aria-hidden="true">

--- a/src/services/daily_planner.py
+++ b/src/services/daily_planner.py
@@ -13,6 +13,7 @@ from typing import List, Dict, Optional
 import os
 import math
 import re
+import concurrent.futures
 
 # 프로젝트 루트 설정
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
@@ -41,7 +42,7 @@ class DailyTravelPlanner:
         
     def create_daily_plan(self, language="English") -> Dict:
         """하루 전체 여행 일정을 생성합니다."""
-        
+
         # 상태 초기화
         self.used_place_names = []
         self.weather_mentioned = False
@@ -52,56 +53,42 @@ class DailyTravelPlanner:
         sigun = self.weather_planner.get_user_sigun_nm()
         if not sigun:
             return {"error": "위치를 확인할 수 없습니다."}
-        
+
         weather = self.weather_planner.get_current_location_weather()
         if not weather:
             return {"error": "날씨 정보를 가져올 수 없습니다."}
-        
-        # None 값 처리
+
         precipitation_type = weather.get('precipitation_type') or 0
         pm10 = weather.get('pm10') or 0
         pm25 = weather.get('pm25') or 0
-        
         is_rainy = precipitation_type > 0
         is_bad_air = (pm10 > 80 or pm25 > 35)
-        
-        # 2. 시간대별 장소 추천 시작
+
+        # 2. 장소 선택 (순차 — anchor 의존)
         time_slots = self._get_time_slots()
-        daily_plan = []
         anchor_lat = self.latitude
         anchor_lng = self.longitude
         morning_attraction_pool = self._build_morning_attraction_pool(
-            sigun=sigun,
-            is_rainy=is_rainy,
-            is_bad_air=is_bad_air,
-            radius_m=8000,
+            sigun=sigun, is_rainy=is_rainy, is_bad_air=is_bad_air, radius_m=8000,
         )
-        
+
+        pending_jobs: List[Dict] = []
+
         for slot in time_slots:
             if slot['period'] == '오전':
-                # 오전: 날씨에 맞는 장소를 먼저 찾은 뒤, 사용자 위치 기준으로 추천
                 places = list(morning_attraction_pool)
             elif slot['period'] == '오후':
-                # 오후: 오전에 찾은 명소 풀을 점심 추천 장소(anchor) 기준으로 재정렬
                 places = self._rank_morning_pool_by_anchor(morning_attraction_pool, anchor_lat, anchor_lng)
             else:
                 places = self._recommend_places_for_slot(
-                    slot,
-                    sigun,
-                    is_rainy,
-                    is_bad_air,
-                    radius_m=5000,
-                    center_lat=anchor_lat,
-                    center_lng=anchor_lng,
+                    slot, sigun, is_rainy, is_bad_air,
+                    radius_m=5000, center_lat=anchor_lat, center_lng=anchor_lng,
                 )
-            
-            # 이미 사용된 장소 제외 필터링
+
             available_places = [p for p in places if p['name'] not in self.used_place_names]
-            
             if not available_places:
                 continue
 
-            # 저녁은 음식점+카페 2개, 나머지는 1개 선택
             selected_items = []
             if slot['period'] == '저녁':
                 dinner = next((p for p in available_places if p.get('itinerary_role') == 'dinner'), None)
@@ -110,62 +97,93 @@ class DailyTravelPlanner:
                 if cafe: selected_items.append(cafe)
             else:
                 selected_items = [available_places[0]]
-            
+
             for selected_place in selected_items:
                 self.used_place_names.append(selected_place['name'])
-                
-                # 도슨트 재료 추출
                 alert_type = self._determine_alert_type(is_rainy, is_bad_air, slot['period'])
-                material = self._get_docent_material(
-                    selected_place['name'],
-                    alert_type,
-                    table_type=selected_place.get('source_type', 'attraction'),
-                    sigun_nm=sigun,
+                place_type = selected_place.get('source_type', 'attraction')
+                # weather_mentioned 상태가 순차이므로 instruction은 여기서 확정
+                instruction = self._get_smart_weather_instruction(slot, is_rainy, is_bad_air, place_type)
+                variation_hint = self._get_slot_style_hint(
+                    slot['period'], place_type, selected_place.get('itinerary_role', '')
                 )
-                
-                if material:
-                    # 문맥 인지형 지침 생성
-                    place_type = selected_place.get('source_type', 'attraction')
-                    material['instruction'] = self._get_smart_weather_instruction(slot, is_rainy, is_bad_air, place_type)
-                    material['variation_hint'] = self._get_slot_style_hint(
-                        slot['period'], place_type, selected_place.get('itinerary_role', '')
-                    )
-                    material['avoid_openers'] = self._used_openers[-3:]
-                    material['avoid_closers'] = self._used_closers[-3:]
-                    material['place_type'] = place_type  # 명소/음식점 구분 정보 추가
-                    material['period'] = slot['period']
-                    material['time_range'] = slot['time']
-                    material['itinerary_role'] = selected_place.get('itinerary_role', '')
-                    
-                    script = self._create_daily_docent_script(material, language=language)
-                    
-                    opener, closer = self._extract_edges(script)
-                    if opener: self._used_openers.append(opener)
-                    if closer: self._used_closers.append(closer)
-                else:
-                    script = f"{slot['period']}에는 {selected_place['name']}에 방문해 보시는 걸 어떨까요?"
-                
-                daily_plan.append({
-                    'time': slot['time'],
-                    'period': slot['period'],
+                pending_jobs.append({
+                    'slot': slot,
                     'place': selected_place,
-                    'script': script
+                    'alert_type': alert_type,
+                    'place_type': place_type,
+                    'instruction': instruction,
+                    'variation_hint': variation_hint,
+                    'itinerary_role': selected_place.get('itinerary_role', ''),
                 })
-
-                # 다음 슬롯은 직전 추천 장소를 기준으로 탐색
                 if selected_place.get('lat') is not None and selected_place.get('lng') is not None:
                     anchor_lat = selected_place['lat']
                     anchor_lng = selected_place['lng']
-        
+
+        if not pending_jobs:
+            return {
+                'location': sigun,
+                'weather': {
+                    'outdoor_status': weather.get('outdoor_status', '정보 없음'),
+                    'temperature': weather.get('temperature'),
+                    'precipitation': '비/눈' if is_rainy else '없음',
+                    'air_quality': '나쁨' if is_bad_air else '보통 이상',
+                },
+                'plan': [],
+            }
+
+        # 3. 도슨트 재료 조회 (병렬 — DB 조회 + 리뷰 없으면 크롤링 포함)
+        def _fetch_material(job):
+            return self._get_docent_material(
+                job['place']['name'],
+                job['alert_type'],
+                table_type=job['place'].get('source_type', 'attraction'),
+                sigun_nm=sigun,
+            )
+
+        n = len(pending_jobs)
+        with concurrent.futures.ThreadPoolExecutor(max_workers=min(n, 5)) as ex:
+            materials = list(ex.map(_fetch_material, pending_jobs))
+
+        # 4. LLM 스크립트 생성 (병렬)
+        def _generate_script(args):
+            job, material = args
+            if not material:
+                return f"{job['slot']['period']}에는 {job['place']['name']}에 방문해 보시는 걸 어떨까요?"
+            mat = dict(material)
+            mat['instruction'] = job['instruction']
+            mat['variation_hint'] = job['variation_hint']
+            mat['avoid_openers'] = []
+            mat['avoid_closers'] = []
+            mat['place_type'] = job['place_type']
+            mat['period'] = job['slot']['period']
+            mat['time_range'] = job['slot']['time']
+            mat['itinerary_role'] = job['itinerary_role']
+            return self._create_daily_docent_script(mat, language=language)
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=min(n, 5)) as ex:
+            scripts = list(ex.map(_generate_script, zip(pending_jobs, materials)))
+
+        # 5. 최종 일정 조합
+        daily_plan = [
+            {
+                'time': job['slot']['time'],
+                'period': job['slot']['period'],
+                'place': job['place'],
+                'script': script,
+            }
+            for job, script in zip(pending_jobs, scripts)
+        ]
+
         return {
             'location': sigun,
             'weather': {
                 'outdoor_status': weather.get('outdoor_status', '정보 없음'),
                 'temperature': weather.get('temperature'),
                 'precipitation': '비/눈' if is_rainy else '없음',
-                'air_quality': '나쁨' if is_bad_air else '보통 이상'
+                'air_quality': '나쁨' if is_bad_air else '보통 이상',
             },
-            'plan': daily_plan
+            'plan': daily_plan,
         }
 
     def _build_morning_attraction_pool(self, sigun: str, is_rainy: bool, is_bad_air: bool, radius_m: int) -> List[Dict]:

--- a/src/services/restaurant_docent.py
+++ b/src/services/restaurant_docent.py
@@ -1,39 +1,513 @@
+"""경기도 지역 맛집 TOP N 통합 스토리텔링 도슨트
+
+여러 식당을 단순 나열이 아닌 하나의 '지역 맛집 투어 가이드' 내러티브로 연결합니다.
+
+주요 함수:
+  rank_restaurants()                  : 카드 매출 + 당근 언급수 기반 IQR 보정 가중치 랭킹
+  fetch_tour_context()                : DB에서 각 식당 컨텍스트 수집
+  generate_tour_script()              : Azure OpenAI LLM으로 통합 스토리텔링 대본 생성
+  synthesize_tour_audio()             : speech_service REST TTS로 MP3 바이트 반환
+  generate_restaurant_tour_docent()   : 전체 파이프라인
+
+설계 원칙:
+  - TTS: azure.cognitiveservices.speech SDK 대신 speech_service.synthesize_speech_mp3 사용
+    (REST 직접 호출 → MP3 bytes 반환 → 웹 API 친화적, SDK 설치 불필요, SSML 음질 우수)
+  - LLM 인증: 환경변수 우선 → vault_manager 폴백 (docent_service.py 패턴)
+  - 하드코딩 경로 없음: 파일 저장은 호출자가 결정, 함수는 bytes/str만 반환
+  - DB 컨텍스트: restaurant_details(요약/분위기/팁) 우선,
+    없으면 restaurant_reviews + gg_restaurant_info 폴백
+"""
+from __future__ import annotations
+
+import logging
 import os
-import psycopg2
+from dataclasses import dataclass, field
+from typing import Any
+
 from openai import AzureOpenAI
-import azure.cognitiveservices.speech as speechsdk
-from dotenv import load_dotenv
-from config.vault_manager import vault
+
+logger = logging.getLogger(__name__)
+
+_VALID_LANGUAGES = {"ko", "en"}
+_LLM_DEFAULT_TIMEOUT: float = 15.0   # 단일 장소(6s)보다 긴 2분 대본용
+_LLM_DEFAULT_MAX_TOKENS: int = 2000  # ~2분 분량 오디오 대본
+
 
 # ==============================================================================
-# 0. 환경 설정 및 리소스 로드 (vault_manager 통일)
+# 헬퍼: 환경변수 파싱
 # ==============================================================================
-load_dotenv()
 
-AZURE_OPENAI_KEY                    = vault.get_secret("azure-openai-key")
-AZURE_OPENAI_ENDPOINT               = vault.get_secret("azure-openai-endpoint")
-AZURE_OPENAI_VERSION                = vault.get_secret("azure-openai-version")
-AZURE_SPEECH_KEY                    = vault.get_secret("azure-speech-key")
-AZURE_SPEECH_REGION                 = vault.get_secret("azure-speech-region")
-AZURE_OPENAI_RESTAURANT_DEPLOYMENT  = vault.get_secret("azure-openai-deployment-name")
+def _float_env(name: str, default: float) -> float:
+    raw = (os.getenv(name) or "").strip()
+    try:
+        return float(raw) if raw else default
+    except Exception:
+        return default
 
-DOCENT_OUTPUT_DIR_MP3 = r"C:\Users\EL030\Desktop\dataschool\3dt-1st-Project\3dt-1st-Project\data\docent\mp3"
-DOCENT_OUTPUT_DIR_SCRIPTS = r"C:\Users\EL030\Desktop\dataschool\3dt-1st-Project\3dt-1st-Project\data\docent\scripts"
 
-# 출력 디렉토리 없으면 생성
-if not os.path.exists(DOCENT_OUTPUT_DIR_MP3):
-    os.makedirs(DOCENT_OUTPUT_DIR_MP3, exist_ok=True)
-if not os.path.exists(DOCENT_OUTPUT_DIR_SCRIPTS):
-    os.makedirs(DOCENT_OUTPUT_DIR_SCRIPTS, exist_ok=True)
+def _int_env(name: str, default: int) -> int:
+    raw = (os.getenv(name) or "").strip()
+    try:
+        return int(raw) if raw else default
+    except Exception:
+        return default
 
-def get_db_and_llm_resources():
-    """Azure OpenAI 클라이언트를 생성합니다 (vault_manager 통일)."""
-    azure_client = AzureOpenAI(
-        azure_endpoint=AZURE_OPENAI_ENDPOINT,
-        api_key=AZURE_OPENAI_KEY,
-        api_version=AZURE_OPENAI_VERSION,
+
+
+# ==============================================================================
+# 반환 타입
+# ==============================================================================
+
+@dataclass
+class TourDocentResult:
+    """지역 맛집 투어 도슨트 생성 결과."""
+
+    restaurant_names: list[str]
+    language: str
+    script: str
+    audio_bytes: bytes | None = None
+    source: str = "llm"       # "llm" | "fallback"
+    restaurant_count: int = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.restaurant_count = len(self.restaurant_names)
+
+
+# ==============================================================================
+# LLM 클라이언트  (docent_service.py 환경변수 → vault 폴백 패턴)
+# ==============================================================================
+
+def _get_llm_client() -> tuple[AzureOpenAI, str]:
+    """(AzureOpenAI client, deployment_name) 반환. 설정 없으면 RuntimeError."""
+    endpoint = (os.getenv("AZURE_OPENAI_ENDPOINT") or "").strip()
+    api_key  = (os.getenv("AZURE_OPENAI_KEY") or "").strip()
+    api_ver  = (os.getenv("AZURE_OPENAI_VERSION") or "").strip()
+    deploy   = (
+        os.getenv("AZURE_OPENAI_DEPLOYMENT_NAME")
+        or os.getenv("AZURE_OPENAI_DEPLOYMENT")
+        or ""
+    ).strip()
+
+    if not (endpoint and api_key and api_ver and deploy):
+        try:
+            from config.vault_manager import get_vault_manager
+            _vm = get_vault_manager()
+            endpoint = endpoint or (_vm.get_secret("azure-openai-endpoint") or "").strip()
+            api_key  = api_key  or (_vm.get_secret("azure-openai-key")      or "").strip()
+            api_ver  = api_ver  or (_vm.get_secret("azure-openai-version")   or "").strip()
+            deploy   = deploy   or (_vm.get_secret("azure-openai-deployment-name") or "").strip()
+        except Exception:
+            pass
+
+    if not (endpoint and api_key and api_ver and deploy):
+        raise RuntimeError(
+            "Azure OpenAI 설정 정보(endpoint/key/version/deployment)가 없습니다."
+        )
+
+    timeout = max(5.0, min(_float_env("DOCENT_TOUR_LLM_TIMEOUT_SEC", _LLM_DEFAULT_TIMEOUT), 60.0))
+    client = AzureOpenAI(
+        azure_endpoint=endpoint,
+        api_key=api_key,
+        api_version=api_ver,
+        max_retries=0,
+        timeout=timeout,
     )
-    return azure_client
+    return client, deploy
+
+
+# ==============================================================================
+# STEP 1: 랭킹  (process_restaurants.py IQR + 가중치 스코어 로직 이식)
+# ==============================================================================
+
+def rank_restaurants(candidate_names: list[str], cursor) -> list[str]:
+    """카드 매출 40% + 당근 언급 60% 가중 스코어로 정렬된 상위 10개 이름 반환.
+
+    IQR 이상치 보정 → Min-Max 정규화 → 가중합 (process_restaurants.py 동일 로직).
+    DB 조회 실패 시 입력 순서 그대로 반환.
+    """
+    if not candidate_names:
+        return []
+
+    try:
+        import pandas as pd
+
+        cursor.execute(
+            """
+            WITH TargetList AS (
+                SELECT unnest(%s::text[]) AS target_name
+            ),
+            TargetInfo AS (
+                SELECT t.target_name AS bizplc_nm, r.sigun_nm, r.bizcond_div_nm_info
+                FROM TargetList t
+                LEFT JOIN locallink.gg_restaurant_info r ON t.target_name = r.bizplc_nm
+            )
+            SELECT
+                ti.bizplc_nm                          AS restaurant_name,
+                COALESCE(c.total_amt, 0)              AS card_score_raw,
+                COALESCE(d.total_mention, 0)          AS daangn_score_raw
+            FROM TargetInfo ti
+            LEFT JOIN locallink.v_card_stats_summary c
+                   ON ti.sigun_nm = c.city AND ti.bizcond_div_nm_info = c.category
+            LEFT JOIN daangn.v_daangn_stats_summary d
+                   ON ti.bizplc_nm = d.place_name AND ti.sigun_nm = d.city_name
+            """,
+            (candidate_names,),
+        )
+        rows = cursor.fetchall()
+        if not rows:
+            return candidate_names[:10]
+
+        df = pd.DataFrame(
+            rows, columns=["restaurant_name", "card_score_raw", "daangn_score_raw"]
+        )
+
+        # IQR Capping — 카드 매출 이상치가 전체 랭킹을 왜곡하는 것을 방지
+        q1, q3 = df["card_score_raw"].quantile([0.25, 0.75])
+        df["card_score_raw"] = df["card_score_raw"].clip(upper=q3 + 1.5 * (q3 - q1))
+
+        # Min-Max 정규화
+        for raw_col, norm_col in [("card_score_raw", "norm_card"), ("daangn_score_raw", "norm_daangn")]:
+            lo, hi = df[raw_col].min(), df[raw_col].max()
+            df[norm_col] = (df[raw_col] - lo) / (hi - lo) if hi > lo else 0.0
+
+        # 가중합: 카드 40% + 당근 60%
+        df["final_score"] = df["norm_card"] * 0.4 + df["norm_daangn"] * 0.6
+        return df.sort_values("final_score", ascending=False)["restaurant_name"].head(10).tolist()
+
+    except Exception as exc:
+        logger.warning("rank_restaurants 쿼리 실패, 입력 순서 그대로 사용: %s", exc)
+        return candidate_names[:10]
+
+
+# ==============================================================================
+# STEP 2: DB 컨텍스트 조회
+# ==============================================================================
+
+def _fetch_single_restaurant_context(cursor, name: str) -> dict[str, Any]:
+    """restaurant_details(분석 데이터) 우선 → gg_restaurant_info + restaurant_reviews 폴백."""
+    ctx: dict[str, Any] = {
+        "name": name,
+        "region": "",
+        "biz_type": "",
+        "address": "",
+        "summary_ko": "",
+        "atmosphere": "",
+        "tips": "",
+        "keywords": "",
+        "review_snippet": "",
+    }
+
+    # 1) restaurant_details — process_restaurants.py가 채운 LLM 분석 결과
+    try:
+        cursor.execute(
+            """
+            SELECT summary_ko, atmosphere_ko, tips_ko
+            FROM locallink.restaurant_details
+            WHERE restaurant_name = %s
+            LIMIT 1
+            """,
+            (name,),
+        )
+        row = cursor.fetchone()
+        if row:
+            ctx["summary_ko"] = (row["summary_ko"]    or "").strip()
+            ctx["atmosphere"] = (row["atmosphere_ko"] or "").strip()
+            ctx["tips"]       = (row["tips_ko"]       or "").strip()
+    except Exception:
+        pass
+
+    # 2) gg_restaurant_info — 업종, 주소, 지역
+    try:
+        cursor.execute(
+            """
+            SELECT sigun_nm, bizcond_div_nm_info,
+                   COALESCE(refine_roadnm_addr, refine_lotno_addr, '') AS address
+            FROM locallink.gg_restaurant_info
+            WHERE bizplc_nm = %s
+            LIMIT 1
+            """,
+            (name,),
+        )
+        row = cursor.fetchone()
+        if row:
+            ctx["region"]   = (row["sigun_nm"]           or "").strip()
+            ctx["biz_type"] = (row["bizcond_div_nm_info"] or "").strip()
+            ctx["address"]  = (row["address"]             or "").strip()
+    except Exception:
+        pass
+
+    # 3) restaurant_reviews — summary가 없을 때 키워드 + 리뷰 스니펫으로 보충
+    if not ctx["summary_ko"]:
+        try:
+            cursor.execute(
+                """
+                SELECT extracted_keywords, clean_text
+                FROM locallink.restaurant_reviews
+                WHERE restaurant_name = %s
+                ORDER BY id DESC
+                LIMIT 2
+                """,
+                (name,),
+            )
+            rows = cursor.fetchall()
+            if rows:
+                ctx["keywords"] = (rows[0]["extracted_keywords"] or "").strip()
+                ctx["review_snippet"] = " / ".join(
+                    (r["clean_text"] or "")[:120]
+                    for r in rows
+                    if (r["clean_text"] or "").strip()
+                )
+        except Exception:
+            pass
+
+    return ctx
+
+
+def fetch_tour_context(restaurant_names: list[str], cursor) -> list[dict[str, Any]]:
+    """식당 이름 리스트 → 각 식당의 컨텍스트 dict 리스트 반환."""
+    return [_fetch_single_restaurant_context(cursor, name) for name in restaurant_names]
+
+
+# ==============================================================================
+# STEP 3: 통합 스토리텔링 대본 생성
+# ==============================================================================
+
+def _build_context_block(ctx: dict[str, Any]) -> str:
+    """단일 식당 컨텍스트 → 프롬프트용 텍스트 블록."""
+    lines = [f"[{ctx['name']}]"]
+    if ctx["region"]:
+        lines.append(f"- 지역: {ctx['region']}")
+    if ctx["biz_type"]:
+        lines.append(f"- 업종: {ctx['biz_type']}")
+    if ctx["summary_ko"]:
+        lines.append(f"- 요약: {ctx['summary_ko']}")
+    if ctx["atmosphere"]:
+        lines.append(f"- 분위기: {ctx['atmosphere']}")
+    if ctx["tips"]:
+        lines.append(f"- 팁: {ctx['tips']}")
+    if ctx["keywords"]:
+        lines.append(f"- 키워드: {ctx['keywords']}")
+    if ctx["review_snippet"]:
+        lines.append(f"- 리뷰: {ctx['review_snippet']}")
+    return "\n".join(lines)
+
+
+def generate_tour_script(
+    restaurant_names: list[str],
+    context_list: list[dict[str, Any]],
+    language: str,
+) -> str:
+    """Azure OpenAI LLM으로 통합 맛집 투어 가이드 대본을 생성합니다."""
+    if language not in _VALID_LANGUAGES:
+        raise ValueError("language must be 'ko' or 'en'")
+
+    full_context = "\n\n".join(_build_context_block(ctx) for ctx in context_list)
+    language_name = "Korean" if language == "ko" else "English"
+    count = len(restaurant_names)
+
+    system_message = (
+        "당신은 'LALA AI Guide', 경기도 근처 맛집을 소개하는 전문 오디오 투어 도슨트입니다.\n"
+        "[대본 작성 원칙]\n"
+        f"1. 내러티브 구조: {count}개 식당을 하나의 여정으로 — 단순 나열 금지."
+        "   분위기·메뉴 특성에 따라 흐름 있게 연결하세요.\n"
+        "2. 구성: 도입(지역 소개 + 기대감 조성) → 음식 여정(각 식당을 스토리로 이어줌)"
+        "   → 마무리(방문 독려)\n"
+        "3. 데이터 기반: 키워드·요약·분위기 정보를 문장에 자연스럽게 녹여 생생함을 더하세요.\n"
+        "4. 말투: 이어폰으로 듣는 오디오 가이드 — 리듬감 있는 구어체, 청자에게 직접 말하는 형식.\n"
+        "5. 없는 사실을 지어내지 마세요.\n"
+        f"6. 분량: 약 2분 분량(300~400 단어). 언어: {language_name}."
+    )
+
+    user_message = (
+        f"아래 TOP {count}개 맛집 데이터를 바탕으로 통합 오디오 투어 가이드 대본을 작성해주세요.\n\n"
+        f"{full_context}"
+    )
+
+    max_tokens = _int_env("DOCENT_TOUR_MAX_TOKENS", _LLM_DEFAULT_MAX_TOKENS)
+    client, deploy = _get_llm_client()
+    response = client.chat.completions.create(
+        model=deploy,
+        temperature=0.7,
+        max_tokens=max_tokens,
+        messages=[
+            {"role": "system", "content": system_message},
+            {"role": "user",   "content": user_message},
+        ],
+    )
+    content = (response.choices[0].message.content or "").strip()
+    if not content:
+        raise RuntimeError("LLM이 빈 대본을 반환했습니다.")
+    return content
+
+
+def _fallback_tour_script(restaurant_names: list[str], language: str) -> str:
+    """LLM 실패 시 기본 안내 대본."""
+    names_str = ", ".join(restaurant_names[:5])
+    tail = " and more." if len(restaurant_names) > 5 else "."
+    if language == "en":
+        return (
+            f"Welcome to your local restaurant tour! "
+            f"Today we recommend: {names_str}{tail} "
+            "Please check each restaurant's hours before visiting."
+        )
+    tail_ko = " 외 여러 곳입니다." if len(restaurant_names) > 5 else "입니다."
+    return (
+        f"안녕하세요, LALA 맛집 투어 가이드입니다. "
+        f"오늘 추천 맛집은 {names_str}{tail_ko} "
+        "방문 전 영업시간을 꼭 확인해 주세요."
+    )
+
+
+# ==============================================================================
+# STEP 4: TTS — speech_service REST 방식 (SDK 불필요, MP3 bytes 반환)
+# ==============================================================================
+
+def synthesize_tour_audio(script: str, language: str) -> bytes:
+    """speech_service.synthesize_speech_mp3로 MP3 bytes를 반환합니다.
+
+    azure.cognitiveservices.speech SDK 대신 Azure Speech REST API를 직접 호출합니다:
+      - 추가 패키지 설치 불필요
+      - MP3 bytes 반환 → 웹 API에서 바로 Response로 streaming 가능
+      - SSML 기반으로 음성 품질이 우수
+    """
+    from src.frontend.web.services.speech_service import synthesize_speech_mp3
+    return synthesize_speech_mp3(script=script, language=language)
+
+
+# ==============================================================================
+# 통합 파이프라인
+# ==============================================================================
+
+def generate_restaurant_tour_docent(
+    restaurant_names: list[str],
+    cursor,
+    language: str = "ko",
+    with_audio: bool = True,
+    auto_rank: bool = False,
+) -> TourDocentResult:
+    """지역 맛집 TOP N 통합 스토리텔링 도슨트를 생성합니다.
+
+    Args:
+        restaurant_names: 이미 선별된 식당명 리스트 (최대 10개 권장).
+        cursor:           psycopg2 DictCursor (트랜잭션 관리는 호출자가 담당).
+        language:         "ko" | "en"
+        with_audio:       True면 MP3 bytes도 생성 (TTS API 비용 발생).
+        auto_rank:        True면 rank_restaurants()로 정렬 후 상위 10개만 사용.
+
+    Returns:
+        TourDocentResult (script, audio_bytes, restaurant_names, language, source)
+    """
+    if language not in _VALID_LANGUAGES:
+        raise ValueError("language must be 'ko' or 'en'")
+    if not restaurant_names:
+        raise ValueError("restaurant_names가 비어 있습니다.")
+
+    names = restaurant_names
+    if auto_rank:
+        names = rank_restaurants(names, cursor)
+    names = names[:10]
+
+    context_list = fetch_tour_context(names, cursor)
+
+    script = ""
+    source = "fallback"
+    try:
+        script = generate_tour_script(names, context_list, language)
+        source = "llm"
+    except Exception as exc:
+        logger.warning(
+            "tour_docent LLM 실패 (count=%d language=%s): %s",
+            len(names), language, exc,
+        )
+        script = _fallback_tour_script(names, language)
+
+    audio_bytes: bytes | None = None
+    if with_audio and script:
+        try:
+            audio_bytes = synthesize_tour_audio(script, language)
+        except Exception as exc:
+            logger.warning("tour_docent TTS 실패: %s", exc)
+
+    return TourDocentResult(
+        restaurant_names=names,
+        language=language,
+        script=script,
+        audio_bytes=audio_bytes,
+        source=source,
+    )
+
+
+# ==============================================================================
+# CLI 테스트 진입점 (restaurant_main.py 파이프라인과 동일한 흐름)
+# ==============================================================================
+
+if __name__ == "__main__":
+    import sys
+    from pathlib import Path
+
+    PROJECT_ROOT = Path(__file__).resolve().parents[2]
+    if str(PROJECT_ROOT) not in sys.path:
+        sys.path.insert(0, str(PROJECT_ROOT))
+
+    from dotenv import load_dotenv
+    import psycopg2
+    import psycopg2.extras
+    from config.vault_manager import get_vault_manager
+
+    load_dotenv()
+    _vm = get_vault_manager()
+
+    # restaurant_main.py와 동일한 파이프라인으로 동작 확인
+    GPS_LAT, GPS_LON = 37.2807, 127.0151
+
+    print("\n" + "🚀 " * 20)
+    print("LALA RESTAURANT TOUR DOCENT: 통합 파이프라인 테스트")
+    print("🚀 " * 20)
+
+    from src.collectors.restaurant_filter import filter_restaurants_by_location
+    from src.collectors.process_restaurants import get_ranked_restaurants
+
+    # STEP 1: 위치 기반 필터링
+    restaurants, status = filter_restaurants_by_location(radius_m=1500, lat=GPS_LAT, lon=GPS_LON)
+    if not restaurants:
+        print(f"⚠️ 주변 식당 없음: {status}")
+        sys.exit(0)
+
+    # STEP 2: 가중치 랭킹 (process_restaurants.py의 get_ranked_restaurants 활용)
+    candidates = [{"restaurant_name": r[0]} for r in restaurants]
+    ranked_df = get_ranked_restaurants(candidates)
+    top_names = (
+        ranked_df["restaurant_name"].tolist()
+        if not ranked_df.empty
+        else [r[0] for r in restaurants[:10]]
+    )
+    print(f"\n✅ TOP {len(top_names)} 선정: {top_names}")
+
+    # STEP 3: 투어 도슨트 생성
+    conn = psycopg2.connect(_vm.get_db_dsn())
+    try:
+        with conn.cursor(cursor_factory=psycopg2.extras.DictCursor) as cur:
+            result = generate_restaurant_tour_docent(
+                restaurant_names=top_names,
+                cursor=cur,
+                language="ko",
+                with_audio=True,
+            )
+        conn.commit()
+    finally:
+        conn.close()
+
+    print(f"\n🌟 [SOURCE: {result.source}] {result.restaurant_count}개 식당 대본 생성 완료")
+    print("-" * 60)
+    print(result.script[:400] + ("..." if len(result.script) > 400 else ""))
+
+    if result.audio_bytes:
+        out_path = Path("data/docent/mp3/restaurant_tour.mp3")
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_bytes(result.audio_bytes)
+        print(f"\n✅ MP3 저장: {out_path}  ({len(result.audio_bytes):,} bytes)")
+    else:
+        print("\n⚠️ 음성 생성 실패 또는 with_audio=False")
 
 # ==============================================================================
 # 1. RAG: DB에서 TOP 10 식당 데이터 일괄 추출 (기존 로직 유지)

--- a/tests/unit/test_map_api_service.py
+++ b/tests/unit/test_map_api_service.py
@@ -72,6 +72,7 @@ def test_normalize_place_row_promotes_id_to_place_id():
 
 def test_create_weather_payload_caches_duplicate_requests(monkeypatch):
     ios_api._reset_weather_cache_for_tests()
+    monkeypatch.setattr(ios_api, "_WEATHER_DB_ENABLED", False)
     calls = {"weather": 0, "air": 0}
 
     def _fake_weather(lat: float, lng: float):
@@ -107,6 +108,7 @@ def test_create_weather_payload_caches_duplicate_requests(monkeypatch):
 
 def test_create_weather_payload_reuses_stale_dust_when_air_quality_fails(monkeypatch):
     ios_api._reset_weather_cache_for_tests()
+    monkeypatch.setattr(ios_api, "_WEATHER_DB_ENABLED", False)
     calls = {"weather": 0, "air": 0}
 
     def _fake_weather(lat: float, lng: float):


### PR DESCRIPTION
<!--
PR 제목 규칙: type(scope): description
예) feat(function): add eventhub trigger
-->

## Summary
<!-- 한 줄로: 무엇을 왜 변경했는지 -->
- 지도 UI/UX 전면 개선, TourAPI 4.0 행사 수집, 날씨 데이터 안정화,
- 맛집 스토리텔링 도슨트 재작성을 포함한 복합 기능 브랜치를 dev에 머지합니다.
- 유닛 테스트 46/46 통과 후 컨테이너 배포를 진행합니다.

## Changes
<!-- 핵심 변경 2~5개 -->
### feat(frontend(web)) — 지도 UX 개선
- 하단 시트 오버레이, 카드 스와이프 제스처, 도슨트 토글 UI
- 이미지 폴백 처리, 날씨 예보 차트 렌더링 개선

### feat(frontend(web)) — Daily Plan
- `/api/plan` 연동, 날씨·미세먼지 기반 실외 활동 간섭 (`outdoor_status`)
- LLM 병렬 호출, 타임아웃 90초로 증가

### feat(ingest) — TourAPI 4.0 행사 수집
- `fetch_tourapi_events.py`: TourAPI 4.0 경기도 행사 128건 수집
- `gyeonggi_events` lat/lng 컬럼 마이그레이션
- `listYN` 미지원 파라미터 제거
- 좌표 지원하는 API라서 추가했어요 임의 사용해서 죄송해요

### feat(frontend(web)) — 행사 상세 표시
- 행사 기간·URL 상세 시트 표시, 만료 행사 시각 구분
- `is_ongoing` 플래그, 진행 중 행사 우선 정렬
- 맛집 탐색 반경 20 km 확대

### fix(frontend(web)) — 날씨 데이터
- DB `temperature` NULL → Open-Meteo `current.temperature_2m` 자동 보충
- `outdoor_status` 백엔드 SELECT 및 반환 추가
- 날씨 예보 빈 배열(`forecast: []`) 수정

### refactor(services) — restaurant_docent.py
- `azure.cognitiveservices.speech` SDK 제거 → `synthesize_speech_mp3` (REST)
- `TourDocentResult` dataclass, IQR + 가중 랭킹, 내러티브 프롬프트 구조화
- LLM 환경변수 → vault fallback, graceful fallback 대본

### fix(ci) — 유닛테스트
- 날씨 캐시 2개 테스트에 `_WEATHER_DB_ENABLED=False` 패치 추가
  (로컬 DB 연결 성공 시 air-quality 경로 우회 현상 격리)

## Test
<!-- 실행한 테스트/확인 (없으면 N/A) -->
- `python -m pytest tests/unit/ -v` → **46 passed, 0 failed**
- 실패 원인: `_WEATHER_DB_ENABLED` 기본 `true` + 로컬 DB 연결 → DB 경로 우선 진입으로 `_fetch_open_meteo_air_quality` 미호출
- 수정: 해당 2개 테스트에 `monkeypatch.setattr(ios_api, '_WEATHER_DB_ENABLED', False)` 추가


## Related
<!-- 이슈 자동 종료: Closes #번호 -->
- Closes #104  feat(frontend(web)): Map UX 개선 + 하루 일정 플래너 with 날씨 개입 알림
- Closes #105  feat(frontend(web)): 지도 UI/UX 전면 개선
- Closes #106  feat(frontend(web)): Daily Plan 기능 추가
- Closes #107  feat(ingest): TourAPI 4.0 행사 수집
- Closes #108  feat(frontend(web)): 행사 상세 표시 개선
- Closes #109  fix(frontend(web)): temperature NULL 보충
- Closes #110  refactor(services): restaurant_docent.py 재작성
- Closes #111  fix(ci): 날씨 캐시 테스트 DB 격리