### PR TITLE
[pipeline] 맛집 랭킹 Decimal 연산 오류 수정 및 성공 로그 추가

### DIFF
--- a/src/services/restaurant_docent.py
+++ b/src/services/restaurant_docent.py
@@ -161,6 +161,10 @@ def rank_restaurants(candidate_names: list[str], cursor) -> list[str]:
             rows, columns=["restaurant_name", "card_score_raw", "daangn_score_raw"]
         )
 
+        # [수정] Decimal -> float 변환 (연산 오류 방지)
+        df["card_score_raw"] = pd.to_numeric(df["card_score_raw"], errors='coerce').fillna(0.0)
+        df["daangn_score_raw"] = pd.to_numeric(df["daangn_score_raw"], errors='coerce').fillna(0.0)
+
         # IQR Capping — 카드 매출 이상치가 전체 랭킹을 왜곡하는 것을 방지
         q1, q3 = df["card_score_raw"].quantile([0.25, 0.75])
         df["card_score_raw"] = df["card_score_raw"].clip(upper=q3 + 1.5 * (q3 - q1))
@@ -444,6 +448,9 @@ def generate_restaurant_tour_docent(
             audio_bytes = synthesize_tour_audio(script, language)
         except Exception as exc:
             logger.warning("tour_docent TTS 실패: %s", exc)
+
+    # [추가] 서버 로그에 성공 메시지 출력 (사용자 확인용)
+    print(f"✅ [Tour Docent] 생성 완료: {len(names)}개 식당 (Source: {source}, Audio: {len(audio_bytes) if audio_bytes else 0} bytes)")
 
     return TourDocentResult(
         restaurant_names=names,


### PR DESCRIPTION
<!--
PR 제목 규칙: type(scope): description
예) feat(function): add eventhub trigger
-->

## Summary
<!-- 한 줄로: 무엇을 왜 변경했는지 -->
- `restaurant_docent.py`의 랭킹 계산 로직에서 발생하던 `Decimal` 타입 연산 오류를 수정하고, 도슨트 생성 완료 여부를 확인할 수 있도록 성공 로그를 추가했습니다.

## Changes
<!-- 핵심 변경 2~5개 -->
- `rank_restaurants` 함수: DB에서 조회한 `Decimal` 타입의 점수 데이터(`card_score_raw`, `daangn_score_raw`)를 `pd.to_numeric`을 사용하여 `float`으로 명시적 변환 (가중치 연산 시 `TypeError` 방지).
- `generate_restaurant_tour_docent` 함수: 모든 처리가 완료된 후 식당 개수와 오디오 파일 크기를 포함한 성공 로그(`✅ [Tour Docent] ...`)를 출력하도록 개선.

## Test
<!-- 실행한 테스트/확인 (없으면 N/A) -- -->
- 로컬 환경에서 맛집 투어 가이드 실행 시 랭킹 계산이 에러 없이 완료됨을 확인.
- 터미널에 성공 로그가 정상적으로 출력되는지 확인.

## Related
<!-- 이슈 자동 종료: Closes #번호 -->
- Closes #121 
